### PR TITLE
Raise a meaningful error if a raw step returns a non-Either object

### DIFF
--- a/lib/dry/transaction/step_adapters/raw.rb
+++ b/lib/dry/transaction/step_adapters/raw.rb
@@ -1,10 +1,18 @@
+require "kleisli"
+
 module Dry
   module Transaction
     class StepAdapters
       # @api private
       class Raw
         def call(step, *args, input)
-          step.operation.call(*args, input)
+          result = step.operation.call(*args, input)
+
+          unless result.is_a?(Kleisli::Either)
+            raise ArgumentError, "step +#{step.step_name}+ must return an Either object"
+          end
+
+          result
         end
       end
 

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -136,4 +136,16 @@ RSpec.describe "Transactions" do
       expect(transaction.call(input).value).to eq "raw failure"
     end
   end
+
+  context "non-confirming raw step result" do
+    let(:input) { {"name" => "Jane", "email" => "jane@doe.com"} }
+
+    before do
+      container[:verify] = -> input { "failure" }
+    end
+
+    it "raises an exception" do
+      expect { transaction.call(input) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
Since I've just merged in a restructure of the step objects, I've implemented @davidpelaez's idea in #12 in the most appropriate new place. Since it was just a few lines, I figured this was simpler than another back and forth on the PR, especially since this gem's also been renamed in the meantime.

Thanks for the suggestion @davidpelaez and for putting your initial PR together! I'll be sure to give you credit in the CHANGELOG :)

Fixes #12 & #11.
