### PR TITLE
Adding option :raise to step adapter Try.

### DIFF
--- a/lib/dry/transaction/step_adapters/try.rb
+++ b/lib/dry/transaction/step_adapters/try.rb
@@ -12,6 +12,7 @@ module Dry
 
           Right(step.operation.call(*args, input))
         rescue *Array(step.options[:catch]) => e
+          e = step.options[:raise].new(e.message) if step.options[:raise]
           Left(e)
         end
       end

--- a/spec/unit/step_adapters/try_spec.rb
+++ b/spec/unit/step_adapters/try_spec.rb
@@ -1,0 +1,98 @@
+RSpec.describe Dry::Transaction::StepAdapters::Try do
+
+  subject { described_class.new }
+
+  let(:operation) {
+    -> (input) {
+      raise(Test::NotValidError, 'not a string') unless input.is_a? String
+      input.upcase
+    }
+  }
+
+  let(:step) {
+    Dry::Transaction::Step.new(subject, :step, :step, operation, options)
+  }
+
+  let(:options) { { catch: Test::NotValidError } }
+
+  before do
+    Test::NotValidError = Class.new(StandardError)
+    Test::BetterNamingError = Class.new(StandardError)
+  end
+
+  describe "#call" do
+
+    context "without the :catch option" do
+      let(:options) { { } }
+
+      it "raises an ArgumentError" do
+        expect do
+          subject.call(step, {})
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with the :catch option" do
+
+      context "when the error was raised" do
+
+        it "return a Left Monad" do
+          expect(subject.call(step, 1234)).to be_a Dry::Monads::Either::Left
+        end
+
+        it "return the raised error as output" do
+          result = subject.call(step, 1234)
+          expect(result.value).to be_a Test::NotValidError
+          expect(result.value.message).to eql 'not a string'
+        end
+
+        context "when using the :raise option" do
+          let(:options) {
+            {
+              catch: Test::NotValidError,
+              raise: Test::BetterNamingError
+            }
+          }
+
+          it "return a Left Monad" do
+            expect(subject.call(step, 1234)).to be_a Dry::Monads::Either::Left
+          end
+
+          it "return the error specified by :raise as output" do
+            result = subject.call(step, 1234)
+            expect(result.value).to be_a Test::BetterNamingError
+            expect(result.value.message).to eql 'not a string'
+          end
+        end
+      end
+
+      context "when the error was NOT raised" do
+
+        it "return a Right Monad" do
+          expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Right
+        end
+
+        it "return the result of the operation as output" do
+          expect(subject.call(step, 'input').value).to eql 'INPUT'
+        end
+
+        context "when using the :raise option" do
+          let(:options) {
+            {
+              catch: Test::NotValidError,
+              raise: Test::BetterNamingError
+            }
+          }
+
+          it "return a Right Monad" do
+            expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Right
+          end
+
+          it "return the result of the operation as output" do
+            expect(subject.call(step, 'input').value).to eql 'INPUT'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this option we can `catch` one type of error and return another type as the value of the Left monad.

My use case was to catch errors like `ActiveRecord::RecordNotFound` but return my own app errors like `MyApp::EntityNotFound`.

If `:raise` is not defined then the step adapter will return the original type from `:catch`.
