### PR TITLE
Use new custom matcher for match block API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 cache: bundler
 bundler_args: --without tools
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "dry-result_matcher", github: "dry-rb/dry-result_matcher", branch: "custom-matchers"
-
 group :test do
   gem "codeclimate-test-reporter", require: nil
   gem "byebug", platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "dry-result_matcher", github: "dry-rb/dry-result_matcher", branch: "custom-matchers"
+
 group :test do
   gem "codeclimate-test-reporter", require: nil
   gem "byebug", platform: :mri

--- a/dry-transaction.gemspec
+++ b/dry-transaction.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["README.md", "LICENSE.md", "Gemfile*", "Rakefile", "lib/**/*", "spec/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.1.0"
 
   spec.add_runtime_dependency "dry-container", ">= 0.2.8"
   spec.add_runtime_dependency "dry-matcher", ">= 0.5.0"

--- a/dry-transaction.gemspec
+++ b/dry-transaction.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_runtime_dependency "dry-container", ">= 0.2.8"
-  spec.add_runtime_dependency "dry-monads", "~> 0.0.1"
+  spec.add_runtime_dependency "dry-matcher", ">= 0.5.0"
+  spec.add_runtime_dependency "dry-monads", ">= 0.0.1"
   spec.add_runtime_dependency "wisper", ">= 1.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.12.2"

--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -44,8 +44,10 @@ module Dry
   #
   # @param options [Hash] the options hash
   # @option options [#[]] :container the operations container
+  # @option options [#[]] :step_adapters (Dry::Transaction::StepAdapters) a custom container of step adapters
+  # @option options [Dry::Matcher] :matcher (Dry::Transaction::ResultMatcher) a custom matcher object for result matching block API
   #
-  # @return [Dry::Transaction::Steps] the transaction object
+  # @return [Dry::Transaction::Sequence] the transaction object
   #
   # @api public
   def self.Transaction(options = {}, &block)

--- a/lib/dry/transaction/dsl.rb
+++ b/lib/dry/transaction/dsl.rb
@@ -1,3 +1,4 @@
+require "dry/transaction/result_matcher"
 require "dry/transaction/step"
 require "dry/transaction/step_adapters"
 require "dry/transaction/sequence"
@@ -9,11 +10,13 @@ module Dry
       attr_reader :container
       attr_reader :step_adapters
       attr_reader :steps
+      attr_reader :matcher
 
       def initialize(options, &block)
         @container = options.fetch(:container)
-        @step_adapters = options.fetch(:step_adapters, StepAdapters)
+        @step_adapters = options.fetch(:step_adapters) { StepAdapters }
         @steps = []
+        @matcher = options.fetch(:matcher) { ResultMatcher }
 
         instance_eval(&block)
       end
@@ -35,7 +38,7 @@ module Dry
       end
 
       def call
-        Sequence.new(steps)
+        Sequence.new(steps, matcher)
       end
     end
   end

--- a/lib/dry/transaction/result_matcher.rb
+++ b/lib/dry/transaction/result_matcher.rb
@@ -1,13 +1,13 @@
-require "dry-result_matcher"
+require "dry-matcher"
 
 module Dry
   module Transaction
-    ResultMatcher = Dry::ResultMatcher::Matcher.new(
-      success: Dry::ResultMatcher::Case.new(
+    ResultMatcher = Dry::Matcher.new(
+      success: Dry::Matcher::Case.new(
         match: -> result { result.right? },
         resolve: -> result { result.value },
       ),
-      failure: Dry::ResultMatcher::Case.new(
+      failure: Dry::Matcher::Case.new(
         match: -> result, step_name = nil {
           if step_name
             result.left? && result.value.step_name == step_name

--- a/lib/dry/transaction/sequence.rb
+++ b/lib/dry/transaction/sequence.rb
@@ -1,5 +1,5 @@
 require "dry/monads/either"
-require "dry/transaction/result_matcher"
+require "dry/transaction/dsl"
 
 module Dry
   module Transaction
@@ -10,8 +10,12 @@ module Dry
       attr_reader :steps
 
       # @api private
-      def initialize(steps)
+      attr_reader :matcher
+
+      # @api private
+      def initialize(steps, matcher)
         @steps = steps
+        @matcher = matcher
       end
 
       # Run the transaction.
@@ -51,7 +55,7 @@ module Dry
         result = steps.inject(Right(input), :bind)
 
         if block
-          ResultMatcher.(result, &block)
+          matcher.(result, &block)
         else
           result.or { |step_failure|
             # Unwrap the value from the StepFailure and return it directly
@@ -140,7 +144,7 @@ module Dry
       def prepend(other = nil, **options, &block)
         other = accept_or_build_transaction(other, **options, &block)
 
-        self.class.new(other.steps + steps)
+        self.class.new(other.steps + steps, matcher)
       end
 
       # Return a transaction with the steps from the provided transaction
@@ -181,7 +185,7 @@ module Dry
       def append(other = nil, **options, &block)
         other = accept_or_build_transaction(other, **options, &block)
 
-        self.class.new(steps + other.steps)
+        self.class.new(steps + other.steps, matcher)
       end
 
       # Return a transaction with the steps from the provided transaction
@@ -234,7 +238,7 @@ module Dry
         other = accept_or_build_transaction(other, **options, &block)
         index = steps.index { |step| step.step_name == insertion_step } + (!!after ? 1 : 0)
 
-        self.class.new(steps.dup.insert(index, *other.steps))
+        self.class.new(steps.dup.insert(index, *other.steps), matcher)
       end
 
       # @overload remove(step, ...)
@@ -256,7 +260,7 @@ module Dry
       #
       #   @api public
       def remove(*steps_to_remove)
-        self.class.new(steps.reject { |step| steps_to_remove.include?(step.step_name) })
+        self.class.new(steps.reject { |step| steps_to_remove.include?(step.step_name) }, matcher)
       end
 
       private

--- a/lib/dry/transaction/sequence.rb
+++ b/lib/dry/transaction/sequence.rb
@@ -1,3 +1,4 @@
+require "dry/monads/either"
 require "dry/transaction/result_matcher"
 
 module Dry
@@ -50,9 +51,12 @@ module Dry
         result = steps.inject(Right(input), :bind)
 
         if block
-          block.call(ResultMatcher.new(result))
+          ResultMatcher.(result, &block)
         else
-          result
+          result.or { |step_failure|
+            # Unwrap the value from the StepFailure and return it directly
+            Left(step_failure.value)
+          }
         end
       end
       alias_method :[], :call

--- a/lib/dry/transaction/step_failure.rb
+++ b/lib/dry/transaction/step_failure.rb
@@ -1,23 +1,12 @@
 module Dry
   module Transaction
-    class StepFailure < BasicObject
-      attr_reader :__step_name
+    class StepFailure
+      attr_reader :step_name
+      attr_reader :value
 
-      def initialize(step_name, object)
-        @__step_name = step_name
-        @__object = object
-      end
-
-      def method_missing(name, *args, &block)
-        @__object.public_send(name, *args, &block)
-      end
-
-      def respond_to_missing?(name, include_private = false)
-        @__object.respond_to?(name, include_private)
-      end
-
-      def ==(other)
-        @__object == other
+      def initialize(step_name, value)
+        @step_name = step_name
+        @value = value
       end
     end
   end

--- a/spec/integration/custom_matcher_spec.rb
+++ b/spec/integration/custom_matcher_spec.rb
@@ -1,0 +1,53 @@
+require "dry-matcher"
+require "dry-monads"
+
+RSpec.describe "Custom matcher" do
+  let(:transaction) {
+    Dry.Transaction(container: container, matcher: Test::CustomMatcher) do
+      step :process
+      step :validate
+      step :persist
+    end
+  }
+
+  let(:container) {
+    {
+      process: -> input { Dry::Monads.Right(name: input["name"], email: input["email"]) },
+      validate: -> input { input[:email].nil? ? Dry::Monads.Left(:email_required) : Dry::Monads.Right(input) },
+      persist:  -> input { Test::DB << input and Dry::Monads.Right(input) }
+    }
+  }
+
+  before do
+    Test::DB = []
+    Test::QUEUE = []
+
+    module Test
+      CustomMatcher = Dry::Matcher.new(
+        yep: Dry::Matcher::Case.new(
+          match: -> result { result.right? },
+          resolve: -> result { result.value }
+        ),
+        nup: Dry::Matcher::Case.new(
+          match: -> result { result.left? },
+          resolve: -> result { result.value.value }
+        )
+      )
+    end
+  end
+
+  it "supports a custom matcher" do
+    matches = -> m {
+      m.yep { |v| "Yep! #{v[:email]}" }
+      m.nup { |v| "Nup. #{v.to_s}" }
+    }
+
+    input = {"name" => "Jane", "email" => "jane@doe.com"}
+    result = transaction.(input, &matches)
+    expect(result).to eq "Yep! jane@doe.com"
+
+    input = {"name" => "Jane"}
+    result = transaction.(input, &matches)
+    expect(result).to eq "Nup. email_required"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,10 @@ if RUBY_ENGINE == "ruby"
   end
 end
 
+begin
+  require "byebug"
+rescue LoadError; end
+
 require "dry-transaction"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
This makes use of the work going on in https://github.com/dry-rb/dry-result_matcher/pull/6.

By using a custom matcher, we can simplify the `StepFailure` object for matching on particular step failures, and then pass the actual failure value directly to the match blocks, rather than having to keep it wrapped up in a StepFailure all the way along, which is prone to errors, because the user actually wants direct access to the object we're wrapping.

It also means we remove code from dry-transaction which was an effective copy of what already existed in dry-result_matcher.

I think this proves that the approach we've taken in https://github.com/dry-rb/dry-result_matcher/pull/6 is helpful, and we should go ahead and merge it :)
