### PR TITLE
StepFailure is initialized with a step and value

### DIFF
--- a/lib/dry/transaction/result_matcher.rb
+++ b/lib/dry/transaction/result_matcher.rb
@@ -10,7 +10,7 @@ module Dry
       failure: Dry::Matcher::Case.new(
         match: -> result, step_name = nil {
           if step_name
-            result.left? && result.value.step_name == step_name
+            result.left? && result.value.step.step_name == step_name
           else
             result.left?
           end

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -37,7 +37,7 @@ module Dry
           value
         }.or { |value|
           broadcast :"#{step_name}_failure", *args, value
-          Left(StepFailure.new(step_name, value))
+          Left(StepFailure.new(self, value))
         }
       end
 

--- a/lib/dry/transaction/step_failure.rb
+++ b/lib/dry/transaction/step_failure.rb
@@ -1,11 +1,11 @@
 module Dry
   module Transaction
     class StepFailure
-      attr_reader :step_name
+      attr_reader :step
       attr_reader :value
 
-      def initialize(step_name, value)
-        @step_name = step_name
+      def initialize(step, value)
+        @step = step
         @value = value
       end
     end


### PR DESCRIPTION
As proposed in https://github.com/dry-rb/dry-transaction/issues/34 this PR initializes the StepFailure with the Step itself instead of just the step_name. So we have more options available when matching the result.
