### PR TITLE
Passing a codeblock given to step through

### DIFF
--- a/lib/dry/transaction/dsl.rb
+++ b/lib/dry/transaction/dsl.rb
@@ -25,17 +25,16 @@ module Dry
         step_adapters.key?(method_name)
       end
 
-      def method_missing(method_name, *args, &cb)
+      def method_missing(method_name, *args, &block)
         return super unless step_adapters.key?(method_name)
 
         step_adapter = step_adapters[method_name]
         step_name = args.first
         options = args.last.is_a?(::Hash) ? args.last : {}
-        options[:λ] = cb unless cb.nil?
         operation_name = options.delete(:with) || step_name
         operation = container[operation_name]
 
-        steps << Step.new(step_adapter, step_name, operation_name, operation, options)
+        steps << Step.new(step_adapter, step_name, operation_name, operation, options, &block)
       end
 
       def call

--- a/lib/dry/transaction/dsl.rb
+++ b/lib/dry/transaction/dsl.rb
@@ -25,12 +25,13 @@ module Dry
         step_adapters.key?(method_name)
       end
 
-      def method_missing(method_name, *args)
+      def method_missing(method_name, *args, &cb)
         return super unless step_adapters.key?(method_name)
 
         step_adapter = step_adapters[method_name]
         step_name = args.first
         options = args.last.is_a?(::Hash) ? args.last : {}
+        options[options[:lambda] ? :λ : :lambda] = cb unless cb.nil?
         operation_name = options.delete(:with) || step_name
         operation = container[operation_name]
 

--- a/lib/dry/transaction/dsl.rb
+++ b/lib/dry/transaction/dsl.rb
@@ -31,7 +31,7 @@ module Dry
         step_adapter = step_adapters[method_name]
         step_name = args.first
         options = args.last.is_a?(::Hash) ? args.last : {}
-        options[options[:lambda] ? :λ : :lambda] = cb unless cb.nil?
+        options[:λ] = cb unless cb.nil?
         operation_name = options.delete(:with) || step_name
         operation = container[operation_name]
 

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -13,6 +13,7 @@ module Dry
       attr_reader :operation_name
       attr_reader :operation
       attr_reader :options
+      attr_reader :lambda
       attr_reader :call_args
 
       def initialize(step_adapter, step_name, operation_name, operation, options, call_args = [])
@@ -21,6 +22,7 @@ module Dry
         @operation_name = operation_name
         @operation = operation
         @options = options
+        @lambda = @options.delete(:λ)
         @call_args = call_args
       end
 
@@ -30,7 +32,7 @@ module Dry
 
       def call(input)
         args = call_args + [input]
-        result = step_adapter.call(self, *args)
+        result = step_adapter.call(self, *args, &@lambda)
 
         result.fmap { |value|
           broadcast :"#{step_name}_success", value

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -13,26 +13,26 @@ module Dry
       attr_reader :operation_name
       attr_reader :operation
       attr_reader :options
-      attr_reader :lambda
+      attr_reader :block
       attr_reader :call_args
 
-      def initialize(step_adapter, step_name, operation_name, operation, options, call_args = [])
+      def initialize(step_adapter, step_name, operation_name, operation, options, call_args = [], &block)
         @step_adapter = step_adapter
         @step_name = step_name
         @operation_name = operation_name
         @operation = operation
         @options = options
-        @lambda = @options.delete(:λ)
+        @block = block
         @call_args = call_args
       end
 
-      def with_call_args(*call_args)
-        self.class.new(step_adapter, step_name, operation_name, operation, options, call_args)
+      def with_call_args(*call_args, &block)
+        self.class.new(step_adapter, step_name, operation_name, operation, options, call_args, &block)
       end
 
       def call(input)
         args = call_args + [input]
-        result = step_adapter.call(self, *args, &@lambda)
+        result = step_adapter.call(self, *args, &block)
 
         result.fmap { |value|
           broadcast :"#{step_name}_success", value

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -26,7 +26,7 @@ module Dry
         @call_args = call_args
       end
 
-      def with_call_args(*call_args, &block)
+      def with_call_args(*call_args)
         self.class.new(step_adapter, step_name, operation_name, operation, options, call_args, &block)
       end
 


### PR DESCRIPTION
Custom steps might require a codeblock to be passed to. After all, the codeblock is the same parameter to call to method as all others. Sometimes it could be handy to be able to write:

``` ruby
Dry.Transaction(container: Container, step_adapters: MyStepAdapters) do
  step :persist
  provided :send_welcome_email do
    step :enqueue_reminder_email
  end
end
```

The example above is oversimplified, but it should give a general impression on what I am missing.

The solution might be straightforward: when the codeblock is passed to `DSL::method_missing`, it’s being re-passed through using `options[:λ]` and extracted from `options` in step constructor.
