### PR TITLE
Step notifications are disabled when passing args

### DIFF
--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -28,7 +28,8 @@ module Dry
       end
 
       def with_call_args(*call_args)
-        self.class.new(step_adapter, step_name, operation_name, operation, options, call_args, &block)
+        @call_args = call_args
+        self
       end
 
       def call(input)

--- a/spec/integration/publishing_step_events_spec.rb
+++ b/spec/integration/publishing_step_events_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "publishing step events" do
 
   let(:container) {
     {
-      process:  -> input { {name: input["name"]} },
+      process:  -> *args, input { {name: input["name"]} },
       verify:   -> input { input[:name].to_s != "" ? Right(input) : Left("no name") },
       persist:  -> input { Test::DB << input and true }
     }
@@ -27,7 +27,7 @@ RSpec.describe "publishing step events" do
     end
 
     specify "subscriber receives success events" do
-      transaction.call("name" => "Jane")
+      transaction.call({ "name" => "Jane" }, process: ['step arg'])
 
       expect(subscriber).to have_received(:process_success).with(name: "Jane")
       expect(subscriber).to have_received(:verify_success).with(name: "Jane")


### PR DESCRIPTION
Passing step args seem to disable notifications for that step. This is
a failing test to highlight the problem. It appears to be due to a new
step instance being created without the subscribers attached.
