### PR TITLE
Flip the order of the operation call args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: ruby
+dist: trusty
 sudo: false
 cache: bundler
 bundler_args: --without tools
+script:
+  - bundle exec rake
+after_success:
+  - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
   - 2.1
   - 2.2
-  - 2.3.0
-  - rbx-2
-  - jruby-9000
-  - ruby-head
-  - jruby-head
-before_install:
-  - gem update bundler
+  - 2.3.1
+  - jruby-9.1.5.0
+env:
+  global:
+    - JRUBY_OPTS='--dev -J-Xmx1024M'
 matrix:
   allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
+    - rvm: rbx-3
 addons:
   code_climate:
     repo_token: 2c92f1dc6b512f11d06153bcf2f3f5b507af6faa95b3319f559bae1a6bcb2c1a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
     end
     ```
 
+## Changed
+
+- `#call` argument order for step operations is now `#call(input, *args)`, not `#call(*args, input)` (timriley)
+
 # 0.8.0 / 2016-07-06
 
 ## Changed

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", require: nil
+  gem "simplecov"
+  gem "codeclimate-test-reporter"
   gem "byebug", platform: :mri
 end
 

--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -10,7 +10,7 @@ module Dry
   #
   # The operations should be addressable via `#[]` in a container object that
   # you pass when creating the transaction. The operations must respond to
-  # `#call(*args, input)`.
+  # `#call(input, *args)`.
   #
   # Each operation will be called in the order it was specified in your
   # transaction, with its output passed as the input to the next operation.

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -32,7 +32,7 @@ module Dry
       end
 
       def call(input)
-        args = call_args + [input]
+        args = [input] + call_args
         result = step_adapter.call(self, *args, &block)
 
         result.fmap { |value|

--- a/lib/dry/transaction/step_adapters/map.rb
+++ b/lib/dry/transaction/step_adapters/map.rb
@@ -5,8 +5,8 @@ module Dry
       class Map
         include Dry::Monads::Either::Mixin
 
-        def call(step, *args, input)
-          Right(step.operation.call(*args, input))
+        def call(step, input, *args)
+          Right(step.operation.call(input, *args))
         end
       end
 

--- a/lib/dry/transaction/step_adapters/raw.rb
+++ b/lib/dry/transaction/step_adapters/raw.rb
@@ -7,8 +7,8 @@ module Dry
       class Raw
         include Dry::Monads::Either::Mixin
 
-        def call(step, *args, input)
-          result = step.operation.call(*args, input)
+        def call(step, input, *args)
+          result = step.operation.call(input, *args)
 
           unless result.is_a?(Dry::Monads::Either)
             raise ArgumentError, "step +#{step.step_name}+ must return an Either object"

--- a/lib/dry/transaction/step_adapters/tee.rb
+++ b/lib/dry/transaction/step_adapters/tee.rb
@@ -5,8 +5,8 @@ module Dry
       class Tee
         include Dry::Monads::Either::Mixin
 
-        def call(step, *args, input)
-          step.operation.call(*args, input)
+        def call(step, input, *args)
+          step.operation.call(input, *args)
           Right(input)
         end
       end

--- a/lib/dry/transaction/step_adapters/try.rb
+++ b/lib/dry/transaction/step_adapters/try.rb
@@ -5,12 +5,12 @@ module Dry
       class Try
         include Dry::Monads::Either::Mixin
 
-        def call(step, *args, input)
+        def call(step, input, *args)
           unless step.options[:catch]
             raise ArgumentError, "+try+ steps require one or more exception classes provided via +catch:+"
           end
 
-          Right(step.operation.call(*args, input))
+          Right(step.operation.call(input, *args))
         rescue *Array(step.options[:catch]) => e
           e = step.options[:raise].new(e.message) if step.options[:raise]
           Left(e)

--- a/spec/integration/custom_step_adapters_spec.rb
+++ b/spec/integration/custom_step_adapters_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "Custom step adapters" do
       class CustomStepAdapters < Dry::Transaction::StepAdapters
         extend Dry::Monads::Either::Mixin
 
-        register :enqueue, -> step, *args, input {
-          Test::QUEUE << step.operation.call(*args, input)
+        register :enqueue, -> step, input, *args {
+          Test::QUEUE << step.operation.call(input, *args)
           Right(input)
         }
       end

--- a/spec/integration/passing_step_arguments_spec.rb
+++ b/spec/integration/passing_step_arguments_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Passing additional arguments to step operations" do
   let(:container) {
     {
       process:  -> input { {name: input["name"], email: input["email"]} },
-      validate: -> allowed, input { !input[:email].include?(allowed) ? raise(Test::NotValidError, "email not allowed") : input },
+      validate: -> input, allowed { !input[:email].include?(allowed) ? raise(Test::NotValidError, "email not allowed") : input },
       persist:  -> input { Test::DB << input and true }
     }
   }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
-if RUBY_ENGINE == "ruby"
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
-
+if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.3"
   require "simplecov"
-  SimpleCov.start do
-    add_filter "/spec/"
-  end
+  SimpleCov.start
 end
 
 begin

--- a/spec/unit/sequence_spec.rb
+++ b/spec/unit/sequence_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Dry::Transaction::Sequence do
       class WithBlockStepAdapters < ::Dry::Transaction::StepAdapters # :nodoc:
         class WithBlock
           include Dry::Monads::Either::Mixin
-          def call(step, *args, input, &cb)
+          def call(step, input, *args, &cb)
             Right(step.operation.((block_given? ? yield(input) : input), *args))
           end
         end

--- a/spec/unit/step_spec.rb
+++ b/spec/unit/step_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Dry::Transaction::Step do
-  let(:step_adapter) { ->(step, *args, input) { step.operation.call(*args, input) } }
+  let(:step_adapter) { ->(step, input, *args) { step.operation.call(input, *args) } }
   let(:step_name) { :test }
   let(:operation_name) { step_name }
 


### PR DESCRIPTION
Before, they were `call(*other_args, input)`

Now, they are `call(input, *other_args)`

This makes it much easier to work with different kinds of argument signatures, like with trailing kwargs, and also support optional args more easily.

This is a breaking behavioural change (but worth it, IMO!), so I'll leave this PR up for a week or so for comment.
