### PR TITLE
Rename Dry::Transaction::Sequence to Dry::Transaction

### DIFF
--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -1,6 +1,7 @@
 require "dry/monads/either"
 require "dry/transaction/version"
 require "dry/transaction/dsl"
+require "dry/transaction/api"
 
 module Dry
   # Define a business transaction.
@@ -47,10 +48,32 @@ module Dry
   # @option options [#[]] :step_adapters (Dry::Transaction::StepAdapters) a custom container of step adapters
   # @option options [Dry::Matcher] :matcher (Dry::Transaction::ResultMatcher) a custom matcher object for result matching block API
   #
-  # @return [Dry::Transaction::Sequence] the transaction object
+  # @return [Dry::Transaction] the transaction object
   #
   # @api public
   def self.Transaction(options = {}, &block)
     Transaction::DSL.new(options, &block).call
+  end
+
+  # This is the class that actually stores the transaction.
+  # To be precise, it stores a series of steps that make up a transaction and
+  # a matcher for handling the result of the transaction.
+  #
+  # Never instantiate this class directly, it is intended to be created through
+  # the provided DSL.
+  class Transaction
+    include API
+
+    # @api private
+    attr_reader :steps
+
+    # @api private
+    attr_reader :matcher
+
+    # @api private
+    def initialize(steps, matcher)
+      @steps = steps
+      @matcher = matcher
+    end
   end
 end

--- a/lib/dry/transaction/dsl.rb
+++ b/lib/dry/transaction/dsl.rb
@@ -2,10 +2,9 @@ require "dry/transaction/result_matcher"
 require "dry/transaction/step"
 require "dry/transaction/step_adapters"
 require "dry/transaction/step_definition"
-require "dry/transaction/sequence"
 
 module Dry
-  module Transaction
+  class Transaction
     # @api private
     class DSL < BasicObject
       attr_reader :container
@@ -46,7 +45,7 @@ module Dry
       end
 
       def call
-        Sequence.new(steps, matcher)
+        Transaction.new(steps, matcher)
       end
     end
   end

--- a/lib/dry/transaction/result_matcher.rb
+++ b/lib/dry/transaction/result_matcher.rb
@@ -1,7 +1,7 @@
 require "dry-matcher"
 
 module Dry
-  module Transaction
+  class Transaction
     ResultMatcher = Dry::Matcher.new(
       success: Dry::Matcher::Case.new(
         match: -> result { result.right? },

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -3,7 +3,7 @@ require "wisper"
 require "dry/transaction/step_failure"
 
 module Dry
-  module Transaction
+  class Transaction
     # @api private
     class Step
       include Wisper::Publisher

--- a/lib/dry/transaction/step_adapters.rb
+++ b/lib/dry/transaction/step_adapters.rb
@@ -1,7 +1,7 @@
 require "dry-container"
 
 module Dry
-  module Transaction
+  class Transaction
     class StepAdapters
       extend Dry::Container::Mixin
     end

--- a/lib/dry/transaction/step_adapters/map.rb
+++ b/lib/dry/transaction/step_adapters/map.rb
@@ -1,5 +1,5 @@
 module Dry
-  module Transaction
+  class Transaction
     class StepAdapters
       # @api private
       class Map

--- a/lib/dry/transaction/step_adapters/raw.rb
+++ b/lib/dry/transaction/step_adapters/raw.rb
@@ -1,7 +1,7 @@
 require "dry/monads/either"
 
 module Dry
-  module Transaction
+  class Transaction
     class StepAdapters
       # @api private
       class Raw

--- a/lib/dry/transaction/step_adapters/tee.rb
+++ b/lib/dry/transaction/step_adapters/tee.rb
@@ -1,5 +1,5 @@
 module Dry
-  module Transaction
+  class Transaction
     class StepAdapters
       # @api private
       class Tee

--- a/lib/dry/transaction/step_adapters/try.rb
+++ b/lib/dry/transaction/step_adapters/try.rb
@@ -1,5 +1,5 @@
 module Dry
-  module Transaction
+  class Transaction
     class StepAdapters
       # @api private
       class Try

--- a/lib/dry/transaction/step_definition.rb
+++ b/lib/dry/transaction/step_definition.rb
@@ -1,5 +1,5 @@
 module Dry
-  module Transaction
+  class Transaction
     # @api private
     class StepDefinition
       include Dry::Monads::Either::Mixin

--- a/lib/dry/transaction/step_failure.rb
+++ b/lib/dry/transaction/step_failure.rb
@@ -1,5 +1,5 @@
 module Dry
-  module Transaction
+  class Transaction
     # A wrapper for storing together the step that failed
     # and value describing the failure.
     class StepFailure

--- a/lib/dry/transaction/version.rb
+++ b/lib/dry/transaction/version.rb
@@ -1,6 +1,6 @@
 module Dry
   # Business transaction DSL.
-  module Transaction
+  class Transaction
     VERSION = "0.8.0".freeze
   end
 end

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Dry::Transaction::Sequence do
+RSpec.describe Dry::Transaction do
   subject(:container) {
     {
       upcase: -> input { input.upcase },


### PR DESCRIPTION
This class was originally CallSheet::Transaction, and we had to find a new name when we renamed the gem to dry-transaction. Sequence never felt like the right name, especially when the object we’re meant to be modelling here is a _business transaction_. This change moves back to using that name directly, and IMO it feels _much_ better.