### PR TITLE
Pass arguments to steps with curry method

### DIFF
--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -75,5 +75,9 @@ module Dry
       @steps = steps
       @matcher = matcher
     end
+
+    def with_step_arguments(new_steps)
+      self.class.new(new_steps, matcher)
+    end
   end
 end

--- a/lib/dry/transaction/api.rb
+++ b/lib/dry/transaction/api.rb
@@ -33,10 +33,6 @@ module Dry
       #
       # @api public
       def call(input, options = {}, &block)
-        assert_valid_options(options)
-        assert_options_satisfy_step_arity(options)
-
-        steps = steps_with_options_applied(options)
         result = steps.inject(Dry::Monads.Right(input), :bind)
 
         if block
@@ -49,6 +45,12 @@ module Dry
         end
       end
       alias_method :[], :call
+
+      def step_args(options = {})
+        assert_valid_options(options)
+        assert_options_satisfy_step_arity(options)
+        with_step_arguments(steps_with_options_applied(options))
+      end
 
       # Subscribe to notifications from steps.
       #

--- a/spec/integration/passing_step_arguments_spec.rb
+++ b/spec/integration/passing_step_arguments_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Passing additional arguments to step operations" do
-  let(:call_transaction) { transaction.call(input, step_options) }
+  let(:call_transaction) { transaction.step_args(step_options).call(input) }
 
   let(:transaction) {
     Dry.Transaction(container: container) do


### PR DESCRIPTION
This implements #51 

@timriley This is not a final solution, but I wanted to share as quick as possible with you, so we can discuss future implementations.

- [ ] We can change the name of the method


 So far what I have done is move all the logic of checking and modifying the step to add the arguments, to the new method `step_args`, at first I thought about just making `steps` an `attr_accessor`, but modifying the state of the object did not seems right, so I created a method following the one in the step class: `with_call_args` to return a new instance of `Transaction` also the method name could be changed.

Hoping to hear your suggestions soon. 

Thanks.

