### PR TITLE
Support calling steps with no input arguments (take 2)

### DIFF
--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -17,7 +17,7 @@ module Dry
         subscribe(listeners) unless listeners.nil?
       end
 
-      def call(input, &block)
+      def call(input = nil, &block)
         assert_step_arity
 
         result = steps.inject(Dry::Monads.Right(input), :bind)

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -56,7 +56,12 @@ module Dry
       end
 
       def arity
-        operation.is_a?(Proc) ? operation.arity : operation.method(:call).arity
+        case operation
+        when Proc, Method
+          operation.arity
+        else
+          operation.method(:call).arity
+        end
       end
     end
   end

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -55,6 +55,14 @@ module Dry
         }
       end
 
+      def call_operation(*input)
+        if arity >= 1
+          operation.call(*input)
+        else
+          operation.call
+        end
+      end
+
       def arity
         case operation
         when Proc, Method

--- a/lib/dry/transaction/step_adapters.rb
+++ b/lib/dry/transaction/step_adapters.rb
@@ -4,16 +4,6 @@ module Dry
   module Transaction
     class StepAdapters
       extend Dry::Container::Mixin
-
-      module Resolver
-        def resolve(step, input, *args)
-          if step.arity >= 1
-            step.operation.call(input, *args)
-          else
-            step.operation.call
-          end
-        end
-      end
     end
   end
 end

--- a/lib/dry/transaction/step_adapters.rb
+++ b/lib/dry/transaction/step_adapters.rb
@@ -4,6 +4,16 @@ module Dry
   module Transaction
     class StepAdapters
       extend Dry::Container::Mixin
+
+      module Resolver
+        def resolve(step, input, *args)
+          if step.arity >= 1
+            step.operation.call(input, *args)
+          else
+            step.operation.call
+          end
+        end
+      end
     end
   end
 end

--- a/lib/dry/transaction/step_adapters/map.rb
+++ b/lib/dry/transaction/step_adapters/map.rb
@@ -4,10 +4,9 @@ module Dry
       # @api private
       class Map
         include Dry::Monads::Either::Mixin
-        include Resolver
 
         def call(step, input, *args)
-          Right(resolve(step, input, *args))
+          Right(step.call_operation(input, *args))
         end
       end
 

--- a/lib/dry/transaction/step_adapters/map.rb
+++ b/lib/dry/transaction/step_adapters/map.rb
@@ -4,9 +4,10 @@ module Dry
       # @api private
       class Map
         include Dry::Monads::Either::Mixin
+        include Resolver
 
         def call(step, input, *args)
-          Right(step.operation.call(input, *args))
+          Right(resolve(step, input, *args))
         end
       end
 

--- a/lib/dry/transaction/step_adapters/raw.rb
+++ b/lib/dry/transaction/step_adapters/raw.rb
@@ -6,9 +6,10 @@ module Dry
       # @api private
       class Raw
         include Dry::Monads::Either::Mixin
+        include Resolver
 
         def call(step, input, *args)
-          result = step.operation.call(input, *args)
+          result = resolve(step, input, *args)
 
           unless result.is_a?(Dry::Monads::Either)
             raise ArgumentError, "step +#{step.step_name}+ must return an Either object"

--- a/lib/dry/transaction/step_adapters/raw.rb
+++ b/lib/dry/transaction/step_adapters/raw.rb
@@ -6,10 +6,9 @@ module Dry
       # @api private
       class Raw
         include Dry::Monads::Either::Mixin
-        include Resolver
 
         def call(step, input, *args)
-          result = resolve(step, input, *args)
+          result = step.call_operation(input, *args)
 
           unless result.is_a?(Dry::Monads::Either)
             raise ArgumentError, "step +#{step.step_name}+ must return an Either object"

--- a/lib/dry/transaction/step_adapters/tee.rb
+++ b/lib/dry/transaction/step_adapters/tee.rb
@@ -4,11 +4,9 @@ module Dry
       # @api private
       class Tee
         include Dry::Monads::Either::Mixin
-        include Resolver
 
         def call(step, input, *args)
-          resolve(step, input, *args)
-
+          step.call_operation(input, *args)
           Right(input)
         end
       end

--- a/lib/dry/transaction/step_adapters/tee.rb
+++ b/lib/dry/transaction/step_adapters/tee.rb
@@ -4,9 +4,11 @@ module Dry
       # @api private
       class Tee
         include Dry::Monads::Either::Mixin
+        include Resolver
 
         def call(step, input, *args)
-          step.operation.call(input, *args)
+          resolve(step, input, *args)
+
           Right(input)
         end
       end

--- a/lib/dry/transaction/step_adapters/try.rb
+++ b/lib/dry/transaction/step_adapters/try.rb
@@ -4,14 +4,14 @@ module Dry
       # @api private
       class Try
         include Dry::Monads::Either::Mixin
-        include Resolver
 
         def call(step, input, *args)
           unless step.options[:catch]
             raise ArgumentError, "+try+ steps require one or more exception classes provided via +catch:+"
           end
 
-          Right(resolve(step, input, *args))
+          result = step.call_operation(input, *args)
+          Right(result)
         rescue *Array(step.options[:catch]) => e
           e = step.options[:raise].new(e.message) if step.options[:raise]
           Left(e)

--- a/lib/dry/transaction/step_adapters/try.rb
+++ b/lib/dry/transaction/step_adapters/try.rb
@@ -4,13 +4,14 @@ module Dry
       # @api private
       class Try
         include Dry::Monads::Either::Mixin
+        include Resolver
 
         def call(step, input, *args)
           unless step.options[:catch]
             raise ArgumentError, "+try+ steps require one or more exception classes provided via +catch:+"
           end
 
-          Right(step.operation.call(input, *args))
+          Right(resolve(step, input, *args))
         rescue *Array(step.options[:catch]) => e
           e = step.options[:raise].new(e.message) if step.options[:raise]
           Left(e)

--- a/spec/integration/transaction_without_steps_spec.rb
+++ b/spec/integration/transaction_without_steps_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe "Transactions steps without arguments" do
+  let(:dependencies) { {} }
+
+  before do
+    Test::NotValidError = Class.new(StandardError)
+    Test::DB = [{"name" => "Jane", "email" => "jane@doe.com"}]
+    Test::Http = Class.new do
+      def self.get
+        "pong"
+      end
+
+      def self.post(value)
+        Test::DB <<  value
+      end
+    end
+    class Test::Container
+      extend Dry::Container::Mixin
+      register :fetch_data,     -> { Test::DB.delete_at(0) }, call: false
+      register :call_outside,   -> { Test::Http.get }, call: false
+      register :external_store, -> input { Test::Http.post(input) }
+      register :process,        -> input { { name: input["name"], email: input["email"] } }
+      register :validate,       -> input { input[:email].nil? ? raise(Test::NotValidError, "email required") : input }
+      register :persist,        -> input { Test::DB << input and true }
+    end
+  end
+
+  context "successful" do
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+          map :fetch_data
+          map :process
+          try :validate, catch: Test::NotValidError
+          tee :persist
+      end.new(**dependencies)
+    }
+
+    it "calls the operations" do
+      transaction.call
+      expect(Test::DB).to include(name: "Jane", email: "jane@doe.com")
+    end
+
+    it "returns a success" do
+      expect(transaction.call()).to be_a Dry::Monads::Either::Right
+    end
+
+    it "wraps the result of the final operation" do
+      expect(transaction.call().value).to eq(name: "Jane", email: "jane@doe.com")
+    end
+
+    it "supports matching on success" do
+      results = []
+
+      transaction.call() do |m|
+        m.success do |value|
+          results << "success for #{value[:email]}"
+        end
+
+        m.failure { }
+      end
+
+      expect(results.first).to eq "success for jane@doe.com"
+    end
+  end
+
+  context "using multiple tee step operators" do
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+          tee :call_outside
+          map :fetch_data
+          map :process
+          try :validate, catch: Test::NotValidError
+          tee :external_store
+      end.new(**dependencies)
+    }
+
+    it "calls the operations" do
+      transaction.call
+      expect(Test::DB).to include(name: "Jane", email: "jane@doe.com")
+    end
+  end
+
+  context "not needing arguments in the middle of the transaction" do
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+          map :process
+          try :validate, catch: Test::NotValidError
+          tee :call_outside
+          tee :external_store
+      end.new(**dependencies)
+    }
+    let(:input) { {"name" => "Jane", "email" => "jane@doe.com"} }
+
+    it "calls the operations" do
+      transaction.call(input)
+      expect(Test::DB).to include(name: "Jane", email: "jane@doe.com")
+    end
+  end
+end


### PR DESCRIPTION
Some steps in a transaction may not accept any input. Make it easy for step adapters to support calling these operations by adding a `Step#call_operation` method. This only calls the operation with args if it accepts any.

@GustavoCaso I tried this as another take on your work in #68. I didn't want to make each step adapter class have to include that `Resolver` module to get this support, so I thought it might be worth adding it on the `Step` class directly. What do you think?