### PR TITLE
allow wrapping steps with private methods

### DIFF
--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -10,7 +10,12 @@ module Dry
 
       def initialize(steps: (self.class.steps), listeners: nil, **operations)
         @steps = steps.map { |step|
-          operation = methods.include?(step.step_name) ? method(step.step_name) : operations[step.step_name]
+          operation =
+            if methods.include?(step.step_name) || private_methods.include?(step.step_name)
+              method(step.step_name)
+            else
+              operations[step.step_name]
+            end
           step.with(operation: operation)
         }
         @operations = operations


### PR DESCRIPTION
There is a bug in current implementation of `Dry::Transaction` [wrapping operations ](http://dry-rb.org/gems/dry-transaction/wrapping-operations), which not allow to make private wrapped methods.
This PR fix this issue.