### PR TITLE
Allow passing call_args to step via DSL within a transaction

### DIFF
--- a/lib/dry/transaction/dsl.rb
+++ b/lib/dry/transaction/dsl.rb
@@ -25,7 +25,7 @@ module Dry
       def define_dsl
         module_exec(@step_adapters) do |step_adapters|
           step_adapters.keys.each do |adapter_name|
-            define_method(adapter_name) do |step_name, with: nil, **options|
+            define_method(adapter_name) do |step_name, with: nil, call_args: [], **options|
               operation_name = with || step_name
 
               steps << Step.new(
@@ -34,6 +34,7 @@ module Dry
                 operation_name,
                 nil, # operations are resolved only when transactions are instantiated
                 options,
+                call_args
               )
             end
           end

--- a/spec/integration/call_args_in_dsl_step_spec.rb
+++ b/spec/integration/call_args_in_dsl_step_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe "Passing additional arguments to step operations unsing step DSL inside transaction" do
+
+  let(:with_call_args_step) {
+    Class.new do
+      include Dry::Transaction(container: Test::Container)
+      map :process, with: :process, call_args: [{ city: 'Moscow' }]
+    end.new
+  }
+
+  let(:without_call_args_step) {
+    Class.new do
+      include Dry::Transaction(container: Test::Container)
+      step :process, with: :process
+    end.new
+  }
+
+  let(:input) { {"name" => "Jane", "email" => "jane@doe.com"} }
+
+  before do
+    Test::NotValidError = Class.new(StandardError)
+    Test::DB = []
+    module Test
+      Container = {
+        process:  -> input, args { args.merge({name: input["name"], email: input["email"]}) },
+      }
+    end
+  end
+
+  context "call_args provided for step" do
+    let(:call_transaction) { with_call_args_step.call(input) }
+    it "passes the arguments and calls the operations successfully" do
+      expect(call_transaction).to eq Right({:city=>"Moscow", :name=>"Jane", :email=>"jane@doe.com"}) 
+    end
+  end
+
+  context "call_args not provided for step" do
+    let(:call_transaction) { without_call_args_step.call(input) }
+    it "raises an ArgumentError" do
+      expect { call_transaction }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
#76