### PR TITLE
Add InvalidStepDefinition error

### DIFF
--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -2,6 +2,7 @@ require "dry/monads/either"
 require "dry/transaction/version"
 require "dry/transaction/step_adapters"
 require "dry/transaction/builder"
+require "dry/transaction/errors"
 
 module Dry
   # Business transaction DSL

--- a/lib/dry/transaction/errors.rb
+++ b/lib/dry/transaction/errors.rb
@@ -1,0 +1,9 @@
+module Dry
+  module Transaction
+    class InvalidStepDefinition < ArgumentError
+      def initialize(key)
+        super("Transaction step `#{key}` must be defined and respond to `#call`")
+      end
+    end
+  end
+end

--- a/lib/dry/transaction/errors.rb
+++ b/lib/dry/transaction/errors.rb
@@ -2,7 +2,13 @@ module Dry
   module Transaction
     class InvalidStepDefinition < ArgumentError
       def initialize(key)
-        super("Transaction step `#{key}` must be defined and respond to `#call`")
+        super("Transaction step `#{key}` must respond to `#call`")
+      end
+    end
+
+    class MissingStepDefinition < ArgumentError
+      def initialize(key)
+        super("Definition for transaction step `#{key}` is missing")
       end
     end
   end

--- a/lib/dry/transaction/errors.rb
+++ b/lib/dry/transaction/errors.rb
@@ -1,12 +1,12 @@
 module Dry
   module Transaction
-    class InvalidStepDefinition < ArgumentError
+    class InvalidStepError < ArgumentError
       def initialize(key)
         super("Transaction step `#{key}` must respond to `#call`")
       end
     end
 
-    class MissingStepDefinition < ArgumentError
+    class MissingStepError < ArgumentError
       def initialize(key)
         super("Definition for transaction step `#{key}` is missing")
       end

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -15,8 +15,10 @@ module Dry
           operation =
             if methods.include?(step.step_name) || private_methods.include?(step.step_name)
               method(step.step_name)
-            else
+            elsif operations[step.step_name].respond_to?(:call)
               operations[step.step_name]
+            else
+              raise InvalidStepDefinition.new(step.step_name)
             end
           step.with(operation: operation)
         }

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -15,6 +15,8 @@ module Dry
           operation =
             if methods.include?(step.step_name) || private_methods.include?(step.step_name)
               method(step.step_name)
+            elsif operations[step.step_name].nil?
+              raise MissingStepDefinition.new(step.step_name)
             elsif operations[step.step_name].respond_to?(:call)
               operations[step.step_name]
             else

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -16,11 +16,11 @@ module Dry
             if methods.include?(step.step_name) || private_methods.include?(step.step_name)
               method(step.step_name)
             elsif operations[step.step_name].nil?
-              raise MissingStepDefinition.new(step.step_name)
+              raise MissingStepError.new(step.step_name)
             elsif operations[step.step_name].respond_to?(:call)
               operations[step.step_name]
             else
-              raise InvalidStepDefinition.new(step.step_name)
+              raise InvalidStepError.new(step.step_name)
             end
           step.with(operation: operation)
         }

--- a/lib/dry/transaction/operation_resolver.rb
+++ b/lib/dry/transaction/operation_resolver.rb
@@ -6,7 +6,11 @@ module Dry
           define_method :initialize do |**kwargs|
             operation_kwargs = self.class.steps.select(&:operation_name).map { |step|
               operation = kwargs.fetch(step.step_name) {
-                ops_container && ops_container.key?(step.operation_name) && ops_container[step.operation_name]
+                if ops_container && ops_container.key?(step.operation_name)
+                  ops_container[step.operation_name]
+                else
+                  nil
+                end
               }
 
               [step.step_name, operation]

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -404,4 +404,96 @@ RSpec.describe "Transactions" do
       expect(transaction.(input).value).to eql(name: 'Jane', age: 20)
     end
   end
+
+  context "invalid steps" do
+    context "non-callable step" do
+      context "with container" do
+        let(:input) { {} }
+
+        let(:transaction) {
+          Class.new do
+            include Dry::Transaction(container: Test::ContainerRaw)
+            map :not_a_proc
+          end.new
+        }
+
+        before do
+          class Test::ContainerRaw
+            extend Dry::Container::Mixin
+
+            register :not_a_proc, "definitely not a proc"
+          end
+        end
+
+        it "raises an exception" do
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
+        end
+      end
+
+      context "no container" do
+        let(:input) { {} }
+
+        let(:transaction) {
+          Class.new do
+            include Dry::Transaction
+            map :not_a_proc
+
+            not_a_proc = "definitelty not a proc"
+          end.new
+        }
+
+        it "raises an exception" do
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
+        end
+      end
+    end
+
+    context "missing steps" do
+      context "no container" do
+        let(:input) { {} }
+
+        let(:transaction) {
+          Class.new do
+            include Dry::Transaction
+            map :noop
+            map :i_am_missing
+
+            def noop
+              Dry::Monads::Right(input)
+            end
+          end.new
+        }
+
+        it "raises an exception" do
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
+        end
+      end
+
+      context "with container" do
+        let(:input) { {} }
+
+        let(:transaction) {
+          Class.new do
+            include Dry::Transaction(container: Test::ContainerRaw)
+            map :noop
+            map :i_am_missing
+
+          end.new
+        }
+
+        before do
+          class Test::ContainerRaw
+            extend Dry::Container::Mixin
+
+            register :noop, -> input { Dry::Monads::Right(input) }
+          end
+        end
+
+        it "raises an exception" do
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
+        end
+      end
+    end
+  end
+
 end

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -429,23 +429,6 @@ RSpec.describe "Transactions" do
           expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
         end
       end
-
-      context "no container" do
-        let(:input) { {} }
-
-        let(:transaction) {
-          Class.new do
-            include Dry::Transaction
-            map :not_a_proc
-
-            not_a_proc = "definitelty not a proc"
-          end.new
-        }
-
-        it "raises an exception" do
-          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
-        end
-      end
     end
 
     context "missing steps" do
@@ -465,7 +448,7 @@ RSpec.describe "Transactions" do
         }
 
         it "raises an exception" do
-          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::MissingStepDefinition)
         end
       end
 
@@ -490,7 +473,7 @@ RSpec.describe "Transactions" do
         end
 
         it "raises an exception" do
-          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::MissingStepDefinition)
         end
       end
     end

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe "Transactions" do
         end
 
         it "raises an exception" do
-          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepDefinition)
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::InvalidStepError)
         end
       end
     end
@@ -448,7 +448,7 @@ RSpec.describe "Transactions" do
         }
 
         it "raises an exception" do
-          expect { transaction.call(input) }.to raise_error(Dry::Transaction::MissingStepDefinition)
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::MissingStepError)
         end
       end
 
@@ -473,7 +473,7 @@ RSpec.describe "Transactions" do
         end
 
         it "raises an exception" do
-          expect { transaction.call(input) }.to raise_error(Dry::Transaction::MissingStepDefinition)
+          expect { transaction.call(input) }.to raise_error(Dry::Transaction::MissingStepError)
         end
       end
     end


### PR DESCRIPTION
Resolves #78.

InvalidStepDefinitionError is raised if step definition does not respond
to `#call`. It covers both missing definitions and improper definitions
(i.e. strings).

Also, OperationResolver used `&&` to chain operations, which lead to
presence of `false` in the result. Got rid of it. Now it's either
object from the container, or a nil.