### PR TITLE
Rename the Either monad to Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.11.0 / to-be-released
 
+## Changed
+
+- Usages of the `Either` monad was updated with `Result` and its constructors. See [the changes](https://github.com/dry-rb/dry-monads/blob/master/CHANGELOG.md#v040-2017-11-11) in `dry-monads` for more details (flash-gordon in [#81][pr81])
+
 ## Fixed
 
 - Pass arguments to a step with keyword arguments with default values (flash-gordon in [#74][pr74])
@@ -7,6 +11,7 @@
 [Compare v0.10.2...master](https://github.com/dry-rb/dry-transaction/compare/v0.10.2...master)
 
 [pr74]: https://github.com/dry-rb/dry-transaction/pull/74
+[pr81]: https://github.com/dry-rb/dry-transaction/pull/81
 
 # 0.10.2 / 2017-07-10
 

--- a/dry-transaction.gemspec
+++ b/dry-transaction.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "dry-container", ">= 0.2.8"
   spec.add_runtime_dependency "dry-matcher", ">= 0.5.0"
-  spec.add_runtime_dependency "dry-monads", ">= 0.0.1"
+  spec.add_runtime_dependency "dry-monads", ">= 0.4.0"
   spec.add_runtime_dependency "wisper", ">= 1.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"

--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -1,4 +1,4 @@
-require "dry/monads/either"
+require "dry/monads/result"
 require "dry/transaction/version"
 require "dry/transaction/step_adapters"
 require "dry/transaction/builder"

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -1,10 +1,10 @@
-require "dry/monads/either"
+require "dry/monads/result"
 require "dry/transaction/result_matcher"
 
 module Dry
   module Transaction
     module InstanceMethods
-      include Dry::Monads::Either::Mixin
+      include Dry::Monads::Result::Mixin
 
       attr_reader :steps
       attr_reader :operations

--- a/lib/dry/transaction/operation.rb
+++ b/lib/dry/transaction/operation.rb
@@ -1,14 +1,14 @@
-require "dry/monads/either"
+require "dry/monads/result"
 require "dry/matcher"
-require "dry/matcher/either_matcher"
+require "dry/matcher/result_matcher"
 
 module Dry
   module Transaction
     module Operation
       def self.included(klass)
         klass.class_eval do
-          include Dry::Monads::Either::Mixin
-          include Dry::Matcher.for(:call, with: Dry::Matcher::EitherMatcher)
+          include Dry::Monads::Result::Mixin
+          include Dry::Matcher.for(:call, with: Dry::Matcher::ResultMatcher)
         end
       end
     end

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -1,4 +1,4 @@
-require "dry/monads/either"
+require "dry/monads/result"
 require "wisper"
 require "dry/transaction/step_failure"
 
@@ -9,7 +9,7 @@ module Dry
       UNDEFINED = Object.new.freeze
 
       include Wisper::Publisher
-      include Dry::Monads::Either::Mixin
+      include Dry::Monads::Result::Mixin
 
       attr_reader :step_adapter
       attr_reader :step_name

--- a/lib/dry/transaction/step_adapters/map.rb
+++ b/lib/dry/transaction/step_adapters/map.rb
@@ -3,7 +3,7 @@ module Dry
     class StepAdapters
       # @api private
       class Map
-        include Dry::Monads::Either::Mixin
+        include Dry::Monads::Result::Mixin
 
         def call(step, input, *args)
           Right(step.call_operation(input, *args))

--- a/lib/dry/transaction/step_adapters/raw.rb
+++ b/lib/dry/transaction/step_adapters/raw.rb
@@ -1,17 +1,17 @@
-require "dry/monads/either"
+require "dry/monads/result"
 
 module Dry
   module Transaction
     class StepAdapters
       # @api private
       class Raw
-        include Dry::Monads::Either::Mixin
+        include Dry::Monads::Result::Mixin
 
         def call(step, input, *args)
           result = step.call_operation(input, *args)
 
-          unless result.is_a?(Dry::Monads::Either)
-            raise ArgumentError, "step +#{step.step_name}+ must return an Either object"
+          unless result.is_a?(Dry::Monads::Result)
+            raise ArgumentError, "step +#{step.step_name}+ must return a Result object"
           end
 
           result

--- a/lib/dry/transaction/step_adapters/tee.rb
+++ b/lib/dry/transaction/step_adapters/tee.rb
@@ -3,7 +3,7 @@ module Dry
     class StepAdapters
       # @api private
       class Tee
-        include Dry::Monads::Either::Mixin
+        include Dry::Monads::Result::Mixin
 
         def call(step, input, *args)
           step.call_operation(input, *args)

--- a/lib/dry/transaction/step_adapters/try.rb
+++ b/lib/dry/transaction/step_adapters/try.rb
@@ -3,7 +3,7 @@ module Dry
     class StepAdapters
       # @api private
       class Try
-        include Dry::Monads::Either::Mixin
+        include Dry::Monads::Result::Mixin
 
         def call(step, input, *args)
           unless step.options[:catch]

--- a/spec/integration/custom_step_adapters_spec.rb
+++ b/spec/integration/custom_step_adapters_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Custom step adapters" do
       }
 
       class CustomStepAdapters < Dry::Transaction::StepAdapters
-        extend Dry::Monads::Either::Mixin
+        extend Dry::Monads::Result::Mixin
 
         register :enqueue, -> step, input, *args {
           Test::QUEUE << step.operation.call(input, *args)

--- a/spec/integration/operation_spec.rb
+++ b/spec/integration/operation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dry::Transaction::Operation do
     end.new
   }
 
-  it "mixes in the Either monad constructors" do
+  it "mixes in the Result monad constructors" do
     expect(operation.("hello")).to be_right
   end
 

--- a/spec/integration/passing_step_arguments_spec.rb
+++ b/spec/integration/passing_step_arguments_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Passing additional arguments to step operations" do
     let(:step_options) { {validate: ["doe.com"]} }
 
     it "passes the arguments and calls the operations successfully" do
-      expect(call_transaction).to be_a Dry::Monads::Either::Right
+      expect(call_transaction).to be_a Dry::Monads::Result::Success
     end
   end
 

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Transactions" do
     end
 
     it "returns a success" do
-      expect(transaction.call(input)).to be_a Dry::Monads::Either::Right
+      expect(transaction.call(input)).to be_a Dry::Monads::Result::Success
     end
 
     it "wraps the result of the final operation" do
@@ -252,7 +252,7 @@ RSpec.describe "Transactions" do
     end
 
     it "returns a failure" do
-      expect(transaction.call(input)).to be_a Dry::Monads::Either::Left
+      expect(transaction.call(input)).to be_a Dry::Monads::Result::Failure
     end
 
     it "wraps the result of the failing operation" do
@@ -334,7 +334,7 @@ RSpec.describe "Transactions" do
     end
 
     it "returns a failure" do
-      expect(transaction.call(input)).to be_a Dry::Monads::Either::Left
+      expect(transaction.call(input)).to be_a Dry::Monads::Result::Failure
     end
 
     it "returns the failing value from the operation" do

--- a/spec/integration/transaction_without_steps_spec.rb
+++ b/spec/integration/transaction_without_steps_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Transactions steps without arguments" do
     end
 
     it "returns a success" do
-      expect(transaction.call()).to be_a Dry::Monads::Either::Right
+      expect(transaction.call()).to be_a Dry::Monads::Result::Success
     end
 
     it "wraps the result of the final operation" do

--- a/spec/support/either_mixin.rb
+++ b/spec/support/either_mixin.rb
@@ -1,3 +1,3 @@
 RSpec.configure do |config|
-  config.include Dry::Monads::Either::Mixin
+  config.include Dry::Monads::Result::Mixin
 end

--- a/spec/unit/step_adapters/map_spec.rb
+++ b/spec/unit/step_adapters/map_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Map do
   describe "#call" do
 
     it "return a Right Monad" do
-      expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Right
+      expect(subject.call(step, 'input')).to be_a Dry::Monads::Result::Success
     end
 
     it "return the result of the operation as output" do

--- a/spec/unit/step_adapters/raw_spec.rb
+++ b/spec/unit/step_adapters/raw_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Raw do
       }
 
       it "return a Left Monad" do
-        expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Left
+        expect(subject.call(step, 'input')).to be_a Dry::Monads::Result::Failure
       end
 
       it "return the result of the operation as output" do
@@ -41,7 +41,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Raw do
       }
 
       it "return a Right Monad" do
-        expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Right
+        expect(subject.call(step, 'input')).to be_a Dry::Monads::Result::Success
       end
 
       it "return the result of the operation as output" do

--- a/spec/unit/step_adapters/tee_spec.rb
+++ b/spec/unit/step_adapters/tee_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Tee do
   describe "#call" do
 
     it "return a Right Monad" do
-      expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Right
+      expect(subject.call(step, 'input')).to be_a Dry::Monads::Result::Success
     end
 
     it "return the original input as output" do

--- a/spec/unit/step_adapters/try_spec.rb
+++ b/spec/unit/step_adapters/try_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Try do
       context "when the error was raised" do
 
         it "return a Left Monad" do
-          expect(subject.call(step, 1234)).to be_a Dry::Monads::Either::Left
+          expect(subject.call(step, 1234)).to be_a Dry::Monads::Result::Failure
         end
 
         it "return the raised error as output" do
@@ -55,7 +55,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Try do
           }
 
           it "return a Left Monad" do
-            expect(subject.call(step, 1234)).to be_a Dry::Monads::Either::Left
+            expect(subject.call(step, 1234)).to be_a Dry::Monads::Result::Failure
           end
 
           it "return the error specified by :raise as output" do
@@ -69,7 +69,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Try do
       context "when the error was NOT raised" do
 
         it "return a Right Monad" do
-          expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Right
+          expect(subject.call(step, 'input')).to be_a Dry::Monads::Result::Success
         end
 
         it "return the result of the operation as output" do
@@ -85,7 +85,7 @@ RSpec.describe Dry::Transaction::StepAdapters::Try do
           }
 
           it "return a Right Monad" do
-            expect(subject.call(step, 'input')).to be_a Dry::Monads::Either::Right
+            expect(subject.call(step, 'input')).to be_a Dry::Monads::Result::Success
           end
 
           it "return the result of the operation as output" do

--- a/spec/unit/step_spec.rb
+++ b/spec/unit/step_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dry::Transaction::Step do
     subject { step.call(input) }
 
     context "when operation succeeds" do
-      let(:operation) { proc { |input| Dry::Monads::Either::Right.new(input) } }
+      let(:operation) { proc { |input| Dry::Monads::Result::Success.new(input) } }
 
       it { is_expected.to be_right }
 
@@ -29,7 +29,7 @@ RSpec.describe Dry::Transaction::Step do
     end
 
     context "when operation fails" do
-      let(:operation) { proc { |input| Dry::Monads::Either::Left.new("error") } }
+      let(:operation) { proc { |input| Dry::Monads::Result::Failure.new("error") } }
 
       it { is_expected.to be_left }
 


### PR DESCRIPTION
Starting `dry-monads 0.4.0` the Either monad was renamed to `Result`, `Left` and `Right` constructors became `Failure` and `Success` accordingly which better reflects the usual purpose of using this monad. For now, the change is backward compatible, but we'll deprecate and remove old constructors before 1.0.