### PR TITLE
Rename “step_called” broadcast event to “step”

### DIFF
--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -51,7 +51,7 @@ module Dry
       end
 
       def with_broadcast(args)
-        broadcast :step_called, step_name, *args
+        broadcast :step, step_name, *args
 
         yield.fmap { |value|
           broadcast :step_succeeded, step_name, *args

--- a/spec/unit/step_spec.rb
+++ b/spec/unit/step_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dry::Transaction::Step do
   describe "#call" do
     let(:listener) do
       Class.new do
-        def step_called(step_name, *args); end
+        def step(step_name, *args); end
         def step_succeeded(step_name, *args); end
         def step_failed(step_name, *args, value); end
       end.new
@@ -32,8 +32,8 @@ RSpec.describe Dry::Transaction::Step do
     context "when operation starts" do
       let(:operation) { proc { |input| Dry::Monads::Result::Right.new(input) } }
 
-      it "publishes step_called" do
-        expect(listener).to receive(:step_called).with(step_name, input)
+      it "publishes step" do
+        expect(listener).to receive(:step).with(step_name, input)
         step.subscribe(listener)
         subject
       end


### PR DESCRIPTION
“step_called” (which is worded in past-tense) would suggest that the step has already been run, which is not the case here; this event is broadcast immediately before running the step.

Relates to the work done in #57, #82, and #83.

With this in place I think these adjusted names are ready for release.