### PR TITLE
Restore broadcast of output value for step_succeeded events (and reorder broadcast args)

### DIFF
--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -54,7 +54,7 @@ module Dry
         broadcast :step, step_name, *args
 
         yield.fmap { |value|
-          broadcast :step_succeeded, step_name, *args
+          broadcast :step_succeeded, step_name, value, *args
           value
         }.or { |value|
           broadcast :step_failed, step_name, value, *args

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -57,7 +57,7 @@ module Dry
           broadcast :step_succeeded, step_name, *args
           value
         }.or { |value|
-          broadcast :step_failed, step_name, *args, value
+          broadcast :step_failed, step_name, value, *args
           Failure(StepFailure.new(self, value))
         }
       end

--- a/spec/integration/publishing_step_events_spec.rb
+++ b/spec/integration/publishing_step_events_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe "publishing step events" do
     specify "subscriber receives success events" do
       transaction.call("name" => "Jane")
 
-      expect(subscriber).to have_received(:step_succeeded).with(:process, "name" => "Jane")
-      expect(subscriber).to have_received(:step_succeeded).with(:verify, name: "Jane")
-      expect(subscriber).to have_received(:step_succeeded).with(:persist, name: "Jane")
+      expect(subscriber).to have_received(:step_succeeded).with(:process, {name: "Jane"}, {"name" => "Jane"})
+      expect(subscriber).to have_received(:step_succeeded).with(:verify, {name: "Jane"}, {name: "Jane"})
+      expect(subscriber).to have_received(:step_succeeded).with(:persist, {name: "Jane"}, {name: "Jane"})
     end
 
-    specify "subsriber receives success events for passing steps, a failure event for the failing step, and no subsequent events" do
+    specify "subscriber receives success events for passing steps, a failure event for the failing step, and no subsequent events" do
       transaction.call("name" => "")
 
-      expect(subscriber).to have_received(:step_succeeded).with(:process, "name" =>  "")
+      expect(subscriber).to have_received(:step_succeeded).with(:process, {name: ""}, {"name" =>  ""})
       expect(subscriber).to have_received(:step_failed).with(:verify, "no name", {name: ""})
       expect(subscriber).not_to have_received(:step_succeeded).with(:persist)
     end
@@ -56,7 +56,7 @@ RSpec.describe "publishing step events" do
     specify "subscriber receives success event for the specified step" do
       transaction.call("name" => "Jane")
 
-      expect(subscriber).to have_received(:step_succeeded).with(:verify, name: "Jane")
+      expect(subscriber).to have_received(:step_succeeded).with(:verify, {name: "Jane"}, {name: "Jane"})
       expect(subscriber).not_to have_received(:step_succeeded).with(:process)
       expect(subscriber).not_to have_received(:step_succeeded).with(:persist)
     end
@@ -86,7 +86,7 @@ RSpec.describe "publishing step events" do
     specify "subscriber receives success event for the specified step" do
       transaction.with_step_args(verify: ["Jane"]).call("name" => "Jane")
 
-      expect(subscriber).to have_received(:step_succeeded).with(:verify, {:name=>"Jane"}, "Jane")
+      expect(subscriber).to have_received(:step_succeeded).with(:verify, {:name=>"Jane"}, {:name=>"Jane"}, "Jane")
       expect(subscriber).not_to have_received(:step_succeeded).with(:process)
       expect(subscriber).not_to have_received(:step_succeeded).with(:persist)
     end

--- a/spec/integration/publishing_step_events_spec.rb
+++ b/spec/integration/publishing_step_events_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "publishing step events" do
       transaction.call("name" => "")
 
       expect(subscriber).to have_received(:step_succeeded).with(:process, "name" =>  "")
-      expect(subscriber).to have_received(:step_failed).with(:verify , {name: ""}, "no name")
+      expect(subscriber).to have_received(:step_failed).with(:verify, "no name", {name: ""})
       expect(subscriber).not_to have_received(:step_succeeded).with(:persist)
     end
   end
@@ -64,7 +64,7 @@ RSpec.describe "publishing step events" do
     specify "subscriber receives failure event for the specified step" do
       transaction.call("name" => "")
 
-      expect(subscriber).to have_received(:step_failed).with(:verify, {name: ""}, "no name")
+      expect(subscriber).to have_received(:step_failed).with(:verify, "no name", {name: ""})
     end
   end
 
@@ -92,9 +92,9 @@ RSpec.describe "publishing step events" do
     end
 
     specify "subscriber receives failure event for the specified step" do
-      transaction.with_step_args(verify: ["Jade"]).call("name" => "")
+      transaction.with_step_args(verify: ["John"]).call("name" => "")
 
-      expect(subscriber).to have_received(:step_failed).with(:verify, {name: ""}, "Jade", "wrong name")
+      expect(subscriber).to have_received(:step_failed).with(:verify, "wrong name", {name: ""}, "John")
     end
   end
 end

--- a/spec/unit/step_spec.rb
+++ b/spec/unit/step_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Dry::Transaction::Step do
       end
 
       it "publishes step_failed" do
-        expect(listener).to receive(:step_failed).with(step_name, input, "error")
+        expect(listener).to receive(:step_failed).with(step_name, "error", "input")
         step.subscribe(listener)
         subject
       end


### PR DESCRIPTION
This PR makes 2 changes:

1. It restores the broadcast of the output value on `step_succeeded` events. This was (inadvertently?) removed in #83, with [this change](https://github.com/dry-rb/dry-transaction/pull/83/files?diff=unified#diff-503c8ab3d6cf49b4e18fe227885fca0fR51) to rename the broadcast event from `#{step_name}_succeeded` to `step_succeeded`.
2. It makes the broadcast arguments consistent across both the `step_succeeded` and `step_failed` events, and moves the output/failure value to be the second argument in the broadcast event, right after step name, with the input args last, since they are variadic/splatted, which would potentially make finding the output value harder to do.

With this change made, subscribers should now have all the information they need, but I wonder if we can make it even clearer by publishing a hash of data instead of these positional args. So instead of this:

```ruby
broadcast :step_succeeded, step_name, value, *args
```

We do this:

```ruby
broadcast :step_succeeded, step: step_name, result: value, args: args
```

Or possibly even this (if we want to separate the single input value from the rest of the step args, which'd be a nice distinction to make, I think):

```ruby
broadcast :step_succeeded, step: step_name, result: value, input: args.first, args: args[1..-1]
```

I'm going to hold up the next release until we can clear this up, since I don't want to have to change the API for the broadcast events twice in quick succession.