### PR TITLE
 Replace wisper with dry-events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'dry-events', git: 'https://github.com/dry-rb/dry-events.git', branch: 'master'
 gem "dry-monads", git: "https://github.com/dry-rb/dry-monads.git"
 gem "dry-matcher", git: "https://github.com/dry-rb/dry-matcher.git"
 

--- a/dry-transaction.gemspec
+++ b/dry-transaction.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-container", ">= 0.2.8"
   spec.add_runtime_dependency "dry-matcher", ">= 0.5.0"
   spec.add_runtime_dependency "dry-monads", ">= 0.4.0"
-  spec.add_runtime_dependency "wisper", ">= 1.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 11.2", ">= 11.2.2"

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -58,7 +58,7 @@ module Dry
         publish(:step, step_name: step_name, args: args)
 
         yield.fmap { |value|
-          publish(:step_succeeded, step_name: step_name, args: args)
+          publish(:step_succeeded, step_name: step_name, args: args, value: value)
           value
         }.or { |value|
           publish(:step_failed, step_name: step_name, args: args, value: value)

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -1,5 +1,5 @@
 require "dry/monads/result"
-require "wisper"
+require 'dry/events/publisher'
 require "dry/transaction/step_failure"
 require "dry/transaction/step_adapter"
 
@@ -10,8 +10,12 @@ module Dry
       UNDEFINED = Object.new.freeze
       RETURN = -> x { x }
 
-      include Wisper::Publisher
+      include Dry::Events::Publisher[object_id]
       include Dry::Monads::Result::Mixin
+
+      register_event('step')
+      register_event('step_succeeded')
+      register_event('step_failed')
 
       attr_reader :step_adapter
       attr_reader :step_name
@@ -51,13 +55,13 @@ module Dry
       end
 
       def with_broadcast(args)
-        broadcast :step, step_name, *args
+        publish('step', step_name: step_name, args: args)
 
         yield.fmap { |value|
-          broadcast :step_succeeded, step_name, *args
+          publish('step_succeeded', step_name: step_name, args: args)
           value
         }.or { |value|
-          broadcast :step_failed, step_name, *args, value
+          publish('step_failed', step_name: step_name, args: args, value: value)
           Failure(StepFailure.new(self, value))
         }
       end

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -13,9 +13,9 @@ module Dry
       include Dry::Events::Publisher[name || object_id]
       include Dry::Monads::Result::Mixin
 
-      register_event('step')
-      register_event('step_succeeded')
-      register_event('step_failed')
+      register_event(:step)
+      register_event(:step_succeeded)
+      register_event(:step_failed)
 
       attr_reader :step_adapter
       attr_reader :step_name
@@ -55,13 +55,13 @@ module Dry
       end
 
       def with_broadcast(args)
-        publish('step', step_name: step_name, args: args)
+        publish(:step, step_name: step_name, args: args)
 
         yield.fmap { |value|
-          publish('step_succeeded', step_name: step_name, args: args)
+          publish(:step_succeeded, step_name: step_name, args: args)
           value
         }.or { |value|
-          publish('step_failed', step_name: step_name, args: args, value: value)
+          publish(:step_failed, step_name: step_name, args: args, value: value)
           Failure(StepFailure.new(self, value))
         }
       end

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -10,7 +10,7 @@ module Dry
       UNDEFINED = Object.new.freeze
       RETURN = -> x { x }
 
-      include Dry::Events::Publisher[object_id]
+      include Dry::Events::Publisher[name || object_id]
       include Dry::Monads::Result::Mixin
 
       register_event('step')


### PR DESCRIPTION
  This PR replace the gem wisper that we currently use for subscribing functionality with the new `dry-events` library 🎉 🎉 

This change introduces two breaking changes in the library.

1. The subscriber class has to respond to the methods `on_step`, `on_step_succedd` and `on_step_failed`

2. The subscriber method will receive an instance of `Dry::Events::Event` with all the information. This is a breaking change because they will have to access the data with the bracket notation `[]`

I didn't want to make any assumptions about what would be the best arguments for each event, since there is a PR of @timriley https://github.com/dry-rb/dry-transaction/pull/88 that cover that topic.