### PR TITLE
Include operation_name in options passed to step adapters

### DIFF
--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -23,7 +23,7 @@ module Dry
       attr_reader :call_args
 
       def initialize(step_adapter, step_name, operation_name, operation, options, call_args = [])
-        @step_adapter = StepAdapter[step_adapter, operation, **options, step_name: step_name]
+        @step_adapter = StepAdapter[step_adapter, operation, **options, step_name: step_name, operation_name: operation_name]
         @step_name = step_name
         @operation_name = operation_name
         @call_args = call_args


### PR DESCRIPTION
The operation name (which for a transaction working with a container, is the operations container identifier) is important for certain 3rd party step adapters, like those that use the operation name to enqueue an operation to run in a background job.

@flash-gordon do you see any issues with this being added back in?