### PR TITLE
Call super initialize

### DIFF
--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -20,8 +20,32 @@ module Dry
         @operations = operations
         @stack = Stack.new(@steps)
         subscribe(listeners) unless listeners.nil?
-        # This fixes the failing test but breaks 42 other tests.
-        # super(*args, **operations)
+
+        next_super_method = method(__method__).super_method
+        super_initialize = nil
+
+        loop do
+          if next_super_method.owner.name =~ /Dry::Transaction/
+            next_super_method = next_super_method.super_method
+          else
+            super_initialize = next_super_method
+            break
+          end
+        end
+
+        if super_initialize && super_initialize.parameters.empty?
+          super()
+        elsif super_initialize
+          super_kwarg_names = super_initialize.parameters.each_with_object([]) { |(type, name), names|
+            names << name if [:key, :keyreq].include?(type)
+          }
+
+          super_kwargs = operations.each_with_object({}) { |(key, val), kwargs|
+            kwargs[key] = val if super_kwarg_names.include?(key)
+          }
+
+          super(*args, **super_kwargs)
+        end
       end
 
       def call(input = nil, &block)

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -12,7 +12,7 @@ module Dry
       attr_reader :listeners
       attr_reader :stack
 
-      def initialize(steps: (self.class.steps), listeners: nil, **operations)
+      def initialize(*args, steps: (self.class.steps), listeners: nil, **operations)
         @steps = steps.map { |step|
           operation = resolve_operation(step, operations)
           step.with(operation: operation)
@@ -20,6 +20,8 @@ module Dry
         @operations = operations
         @stack = Stack.new(@steps)
         subscribe(listeners) unless listeners.nil?
+        # This fixes the failing test but breaks 42 other tests.
+        # super(*args, **operations)
       end
 
       def call(input = nil, &block)

--- a/spec/integration/user_class_hierarchy_spec.rb
+++ b/spec/integration/user_class_hierarchy_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe "dry transaction used with inheriting user classes" do
+  let(:base_class) do
+    Class.new do
+      attr_reader :base_called
+
+      def initialize(*_args)
+        @base_called = true
+      end
+    end
+  end
+
+  let(:child_class) do
+    Class.new(base_class) do
+      include Dry::Transaction
+    end
+  end
+
+  context "when user class inherits from another class" do
+    subject { child_class.new }
+
+    it "calls base class initializer" do
+      expect(subject.base_called).to be true
+    end
+  end
+end


### PR DESCRIPTION
This PR builds on @radanskoric's on in #93 and adds the beginning of a solution for determining whether and how to call `super` from inside `Dry::Transaction::InstanceMethods#initialize`.

@radanskoric Thanks for getting this started! How does something like this look to you?

This takes some logic from dry-auto_inject's `kwargs` strategy for determining which args to pass to super. It needs to do something different for finding the _actual_ super `#initialize` method, though, since we want to pass through any `#initialize` methods provided by dry-transaction itself (e.g. the other on in `Dry::Transaction::OperationResolver`), but one from an _actual_ superclass.

It _might_ actually be possible to use dry-auto_inject itself to handle our work here, instead of doing operation resolution on our own. This may be worth a quick investigation.

Otherwise, there's still some tidying up to do there, but I feel like we're on the right track to respect super initialize methods now. Let me know what you think!