### PR TITLE
Add test interface

### DIFF
--- a/lib/dry/transaction/enable_injection.rb
+++ b/lib/dry/transaction/enable_injection.rb
@@ -1,0 +1,19 @@
+module Dry
+  module Transaction
+    module EnableInjection
+      module Inject
+        def resolve_operation(step, **operations)
+          operation = operations[step.step_name] if operations[step.step_name].respond_to?(:call)
+          operation || super
+        end
+      end
+
+      module_function
+
+      def call(transaction)
+        transaction.include Dry::Transaction::EnableInjection::Inject
+        transaction
+      end
+    end
+  end
+end

--- a/spec/integration/test_interface_spec.rb
+++ b/spec/integration/test_interface_spec.rb
@@ -1,0 +1,75 @@
+require "dry/transaction/enable_injection"
+
+RSpec.describe "Use test interface to fully replace operations with injected ones" do
+
+  before do
+    Test::DB = []
+    Test::Container = container
+    Dry::Transaction::EnableInjection.call(transaction_class)
+  end
+
+  let(:dependencies) { {process: ->input { {name: input["name"].upcase} }} }
+
+  context "without container operation and local defined operation" do
+    let(:container) {
+      Class.new do
+        extend Dry::Container::Mixin
+
+        register :verify,  ->input { input[:name].to_s != "" ? Dry::Monads.Success(input) : Dry::Monads.Failure("no name") }
+        register :persist, ->input { Test::DB << input and true }
+      end
+    }
+
+    let(:transaction_class) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+
+        map :process
+        step :verify, with: :verify
+        tee :persist, with: :persist
+
+        def proccess(input)
+          { name: input["name"] }
+        end
+      end
+    }
+
+    context "when injecting operation" do
+      it "use injected operation instead of local method" do
+        transaction = transaction_class.new(**dependencies)
+        transaction.call("name" => "Jane")
+        expect(Test::DB).to include(name: "JANE")
+      end
+    end
+  end
+
+  context "with container operation" do
+    let(:container) {
+      Class.new do
+        extend Dry::Container::Mixin
+
+        register :process, ->input { {name: input["name"]} }
+        register :verify,  ->input { input[:name].to_s != "" ? Dry::Monads.Success(input) : Dry::Monads.Failure("no name") }
+        register :persist, ->input { Test::DB << input and true }
+      end
+    }
+
+    let(:transaction_class) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+
+        map :process, with: :process
+        step :verify, with: :verify
+        tee :persist, with: :persist
+      end
+    }
+
+    context "when injecting operation" do
+      it "use injected operation instead of container base" do
+        transaction = transaction_class.new(**dependencies)
+        transaction.call("name" => "Jane")
+        expect(Test::DB).to include(name: "JANE")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#75 

This adds a test interface that allows for injected operations to fully replace `local defined operations` and `container base operations`.

The idea behind this is that for testing porpuses is to be able to fully replace operations with injected ones, avoiding unwanted behavior in our tests.

My first idea was to add a class method to the transaction something like `Transaction.enable_injection!` but since the returning class after creating a transaction class is an anonymous class make it harder to add methods. I decided to use a wrapping module that injects this functionality by overwriting the `resolve_operation` method from the `InstanceMethods` module.
I think is a good start for improving the library and help user test their transaction classes.

@timriley WDYT?