### PR TITLE
Unwrapping failure in around step to fix matching

### DIFF
--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -1,7 +1,7 @@
 require "dry/monads/result"
 require "dry/transaction/version"
-require "dry/transaction/step_adapters"
 require "dry/transaction/builder"
+require "dry/transaction/step_adapters"
 require "dry/transaction/errors"
 
 module Dry

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -63,7 +63,7 @@ module Dry
           value
         }.or { |value|
           publish(:step_failed, step_name: step_name, args: args, value: value)
-          Failure(StepFailure.new(self, value))
+          Failure(step_adapter.failure_class.new(self, value))
         }
       end
 

--- a/lib/dry/transaction/step_adapter.rb
+++ b/lib/dry/transaction/step_adapter.rb
@@ -27,6 +27,9 @@ module Dry
         @operation = Callable[operation]
 
         @options = options
+        if defined?(adapter.failure_class)
+          @options[:failure_class] ||= adapter.failure_class
+        end
 
         @yields = @adapter.
                     parameters.
@@ -43,6 +46,10 @@ module Dry
 
       def with(operation = self.operation, new_options = {})
         self.class.new(adapter, operation, options.merge(new_options))
+      end
+
+      def failure_class
+        options[:failure_class] || StepFailure
       end
     end
   end

--- a/lib/dry/transaction/step_adapters/around.rb
+++ b/lib/dry/transaction/step_adapters/around.rb
@@ -3,6 +3,20 @@ require "dry/transaction/errors"
 
 module Dry
   module Transaction
+    class AroundStepFailure < StepFailure
+      attr_reader :around_step
+
+      def initialize(step, value)
+        if value.is_a? Dry::Transaction::StepFailure
+          @around_step = step
+          @step = value.step
+          @value = value.value
+        else
+          super(step, value)
+        end
+      end
+    end
+
     class StepAdapters
       # @api private
       class Around
@@ -16,6 +30,10 @@ module Dry
           end
 
           result
+        end
+
+        def failure_class
+          AroundStepFailure
         end
       end
 

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -388,6 +388,40 @@ RSpec.describe "Transactions" do
     end
   end
 
+  context "failed in an around step" do
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+        around :log
+
+        map :process
+        step :verify
+        try :validate, catch: Test::NotValidError
+        tee :persist
+
+        def log(input, &block)
+          Test::Container[:database] << "Logging input #{input}"
+          block.(Success(input))
+        end
+      end.new(**dependencies)
+    }
+    let(:input) { {"name" => "Jane"} }
+
+    it "supports matching on specific step failures" do
+      results = []
+
+      transaction.call(input) do |m|
+        m.success { }
+
+        m.failure :validate do |value|
+          results << "Validation failure: #{value}"
+        end
+      end
+
+      expect(results.first).to eq "Validation failure: email required"
+    end
+  end
+
   context "failed in a raw step" do
     let(:input) { {"name" => "Jane", "email" => "jane@doe.com"} }
 


### PR DESCRIPTION
#99 

Based on @timriley [suggestion](https://github.com/dry-rb/dry-transaction/issues/99#issuecomment-387569170), `Around` step adapter now has its own `StepFailure` subclass. This subclass unwraps the step failure contained in value and adds an `around_step` instance variable to keep track of the failed around step.    
Matching the failing step of a transaction using an around step adapter is now tested, and working.

It's my first PR on dry-rb and I am quite new to the functional world, so please don't hesitate to point my possible misunderstandings of the codebase or paradigm.