### PR TITLE
Allow replacement of internal steps

### DIFF
--- a/lib/dry/transaction/dsl.rb
+++ b/lib/dry/transaction/dsl.rb
@@ -26,7 +26,7 @@ module Dry
         module_exec(@step_adapters) do |step_adapters|
           step_adapters.each do |adapter_name, adapter|
             define_method(adapter_name) do |step_name, with: nil, **options|
-              operation_name = with || step_name
+              operation_name = with
 
               steps << Step.new(
                 adapter: adapter,

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -86,12 +86,12 @@ module Dry
           operations[step.name]
         elsif methods.include?(step.name) || private_methods.include?(step.name)
           method(step.name)
-        elsif operations[step.name].nil?
-          raise MissingStepError.new(step.name)
         elsif operations[step.name].respond_to?(:call)
           operations[step.name]
-        else
+        elsif operations[step.name]
           raise InvalidStepError.new(step.name)
+        else
+          raise MissingStepError.new(step.name)
         end
       end
 

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -80,12 +80,11 @@ module Dry
 
         operation.(*args, &block)
       end
-      # if step.internal? && operations[step.name]
-      #   operations[step.name]
-      # elsif methods.include?(step.name) || private_methods.include?(step.name)
 
       def resolve_operation(step, **operations)
-        if methods.include?(step.name) || private_methods.include?(step.name)
+        if step.internal? && operations[step.name]
+          operations[step.name]
+        elsif methods.include?(step.name) || private_methods.include?(step.name)
           method(step.name)
         elsif operations[step.name].nil?
           raise MissingStepError.new(step.name)

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -70,6 +70,14 @@ module Dry
         }
       end
 
+      def internal?
+        !external?
+      end
+
+      def external?
+        !!operation_name
+      end
+
       def arity
         adapter.operation.arity
       end

--- a/spec/integration/around_spec.rb
+++ b/spec/integration/around_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe "around steps" do
     Class.new do
       include Dry::Transaction(container: Test::Container)
 
-      around :transaction
-      step :validate
-      step :persist_user
-      step :persist_account
-      step :finalize
+      around :transaction, with: :transaction
+      step :validate, with: :validate
+      step :persist_user, with: :persist_user
+      step :persist_account, with: :persist_account
+      step :finalize, with: :finalize
     end
   end
 

--- a/spec/integration/transaction_without_steps_spec.rb
+++ b/spec/integration/transaction_without_steps_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe "Transactions steps without arguments" do
     let(:transaction) {
       Class.new do
         include Dry::Transaction(container: Test::Container)
-          map :fetch_data
-          map :process
-          try :validate, catch: Test::NotValidError
-          tee :persist
+          map :fetch_data, with: :fetch_data
+          map :process, with: :process
+          try :validate, with: :validate, catch: Test::NotValidError
+          tee :persist, with: :persist
       end.new(**dependencies)
     }
 
@@ -67,11 +67,11 @@ RSpec.describe "Transactions steps without arguments" do
     let(:transaction) {
       Class.new do
         include Dry::Transaction(container: Test::Container)
-          tee :call_outside
-          map :fetch_data
-          map :process
-          try :validate, catch: Test::NotValidError
-          tee :external_store
+          tee :call_outside, with: :call_outside
+          map :fetch_data, with: :fetch_data
+          map :process, with: :process
+          try :validate, with: :validate, catch: Test::NotValidError
+          tee :external_store, with: :external_store
       end.new(**dependencies)
     }
 
@@ -85,10 +85,10 @@ RSpec.describe "Transactions steps without arguments" do
     let(:transaction) {
       Class.new do
         include Dry::Transaction(container: Test::Container)
-          map :process
-          try :validate, catch: Test::NotValidError
-          tee :call_outside
-          tee :external_store
+          map :process, with: :process
+          try :validate, with: :validate, catch: Test::NotValidError
+          tee :call_outside, with: :call_outside
+          tee :external_store, with: :external_store
       end.new(**dependencies)
     }
     let(:input) { {"name" => "Jane", "email" => "jane@doe.com"} }


### PR DESCRIPTION
So @GustavoCaso and I have been talking about addressing #75 and making it possible to provide replacement for "internal" transaction steps (i.e. steps which are backed by instance methods only). The inability to do this feels to me the only big gap we left after moving to class-based transactions, and given an increased in the number of people using container-less transactions, it would be good to get it in place.

@GustavoCaso, I've taken a different approach to what you've done recently, and I think it might work out.

This PR makes one big change in the way we understand steps:

- Any "external" steps _must_ provide a `with:` option (where "external" means the step operation can be resolved from a container or provided whenever the transaction is initialized

Then, when an "internal" step ("internal" meaning a step implanted by an instance method only) has a matching object passed to the initializer, that object fully replaces whatever was previously provided by the instance method

This is a breaking change:

- Obviously, `with:` will need to be provided if anyone was previously relying on the implicit behaviour of the step name also being used to try and find the step operation in a container. Now that we have class-based transactions, my hunch is that not many people will be doing this. Anyone seriously working with containers will have longer container identifiers and will already have `with:` options in every place they need.
- But more subtly, previously it was possible to define a step like `step :foo` and then pass `foo:` to the initializer, and have a the `#foo` instance method still run and call `super` to call the operation object passed in as `foo:`. However, I don't think many people would be doing this, and they can still keep this same behaviour by defining the step as `step :foo, with: :foo`.

So I don't think the breaking changes here are too big, and I think the result is actually a much clearer separation of behaviours.

Plus, I'm much happier to merge something like this in given how small a change it ended up being.

What do you think?

@flash-gordon would be great to get your input, too.