### PR TITLE
Travis: Update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.1
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,16 @@
 language: ruby
 dist: trusty
-sudo: false
 cache: bundler
 bundler_args: --without tools
-before_install:
-  - gem update --system
-  - gem install bundler
-script:
-  - bundle exec rake
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - jruby-9.1.10.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
+  - jruby-9.2.5.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,11 @@ group :tools do
   gem "pry"
   gem "rubocop"
 end
+
+group :development, :test do
+  gem "bundler"
+  gem "rake", "~> 11.2", ">= 11.2.2"
+  gem "rspec"
+  gem "simplecov"
+  gem "yard"
+end

--- a/dry-transaction.gemspec
+++ b/dry-transaction.gemspec
@@ -21,10 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-events", ">= 0.1.0"
   spec.add_runtime_dependency "dry-matcher", ">= 0.7.0"
   spec.add_runtime_dependency "dry-monads", ">= 0.4.0"
-
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 11.2", ">= 11.2.2"
-  spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "yard"
 end


### PR DESCRIPTION
This PR updates CI matrix versions.

  - move dev deps from gemspec to Gemfile (compatibility with more Bundlers)
  - allow Bundler to be installed by rvm (picking a compatible version per MRI version)