### PR TITLE
[WIP] Allow steps to take inputs from any output

### DIFF
--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -106,7 +106,7 @@ module Dry
       def assert_step_arity
         steps.each do |step|
           num_args_required = step.arity >= 0 ? step.arity : ~step.arity
-          num_args_supplied = step.call_args.length + 1 # add 1 for main `input`
+          num_args_supplied = step.call_args.length + step.inputs_arity
 
           if num_args_required > num_args_supplied
             raise ArgumentError, "not enough arguments supplied for step +#{step.name}+"

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -45,8 +45,8 @@ module Dry
         )
       end
 
-      def call(input, continue = RETURN)
-        args = [input, *call_args]
+      def call(inputs, continue = RETURN)
+        args = [*inputs, *call_args]
 
         if adapter.yields?
           with_broadcast(args) { adapter.(args, &continue) }
@@ -84,6 +84,16 @@ module Dry
 
       def operation
         adapter.operation
+      end
+
+      # @see StepAdapter#inputs
+      def inputs(previous_outputs)
+        adapter.inputs(previous_outputs)
+      end
+
+      # @see StepAdapter#inputs_arity
+      def inputs_arity
+        adapter.inputs_arity
       end
     end
   end

--- a/lib/dry/transaction/step_adapter.rb
+++ b/lib/dry/transaction/step_adapter.rb
@@ -2,8 +2,19 @@ require "dry/transaction/callable"
 
 module Dry
   module Transaction
+    # `:input` option controls which previous step outputs are taken
+    # as step inputs. Its value must be a list of previous step names
+    # or {INITIAL_INPUT_KEY} for the initial transaction input. If it
+    # is nil, it defaults to the previous step output. When it is the
+    # empty list, it acts like the "continue" (`>>`) monad operation
+    # instead of the common bind (`>>=`).
+    #
     # @api private
     class StepAdapter
+      # Key to reference the initial transaction input from the `:inputs`
+      # option.
+      INITIAL_INPUT_KEY = :_initial
+
       def self.[](adapter, operation, options)
         if adapter.is_a?(self)
           adapter.with(operation, options)
@@ -43,6 +54,37 @@ module Dry
 
       def with(operation = self.operation, new_options = {})
         self.class.new(adapter, operation, options.merge(new_options))
+      end
+
+      # Selects previous steps outputs to apply to the step from a
+      # given accumulated list.
+      #
+      # @param previous_outputs [Array<Array<Symbol, Result<Any>>>]
+      # List of two element tuples [step name, step output].
+      #   @example
+      #     [
+      #       [:process, Success({ name: "Joe" })],
+      #       [:persist, Success({ id: 1, name: "Joe" })
+      #     ]
+      # @return [Array<Any>]
+      def inputs(previous_outputs)
+        step_names = options[:input]
+        return [previous_outputs.last[1]] if step_names.nil?
+
+        step_names.map do |step_name|
+          previous_outputs.find do |output|
+            output[0] == step_name
+          end[1]
+        end
+      end
+
+      # Arity of inputs of previous steps outputs.
+      #
+      # @return [Integer]
+      def inputs_arity
+        step_names = options[:input]
+
+        step_names ? step_names.length : 1
       end
     end
   end

--- a/spec/integration/using_previous_steps_output_with_input_option_spec.rb
+++ b/spec/integration/using_previous_steps_output_with_input_option_spec.rb
@@ -1,0 +1,132 @@
+RSpec.describe "Using previous steps output with :input option" do
+  include_context "database"
+
+  before do
+    container.instance_exec do
+      register :process,  -> input { { name: input["name"] } }
+      register :persist,  -> input do
+        tuple = { id: 1, name: input[:name] }
+        self[:database] << tuple and tuple
+      end
+    end
+  end
+
+  let(:initial_input) { { "name" => "Jane" } }
+  let(:process_output) { { name: "Jane" } }
+  let(:persist_output) { { id: 1, name: "Jane" } }
+
+  context "using previous steps output" do
+    before do
+      container.instance_exec do
+        register :log, -> process_output, persist_output { "Processed #{process_output} persisted as #{persist_output}"  }
+      end
+    end
+
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+        map :process, with: :process
+        map :persist, with: :persist
+        map :log, with: :log, input: [:process, :persist]
+      end.new
+    }
+
+    it "can reference previous steps with the step name" do
+      result = transaction.call(initial_input)
+
+      expect(result.value!).to eq("Processed #{process_output} persisted as #{persist_output}")
+    end
+  end
+
+  context "using previous steps output in different order" do
+    before do
+      container.instance_exec do
+        register :log, -> persist_output, process_output { "Persisted #{persist_output} from processed #{process_output}"  }
+      end
+    end
+
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+        map :process, with: :process
+        map :persist, with: :persist
+        map :log, with: :log, input: [:persist, :process]
+      end.new
+    }
+
+    it "can specify an order different than the execution order" do
+      result = transaction.call(initial_input)
+
+      expect(result.value!).to eq("Persisted #{persist_output} from processed #{process_output}")
+    end
+  end
+
+  context "using initial input" do
+    before do
+      container.instance_exec do
+        register :log, -> initial_input { "Original #{initial_input} persisted"  }
+      end
+    end
+
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+        map :process, with: :process
+        tee :persist, with: :persist
+        map :log, with: :log, input: [:_initial]
+      end.new
+    }
+
+    it "can reference initial input with :_initial" do
+      result = transaction.call(initial_input)
+
+      expect(result.value!).to eq("Original #{initial_input} persisted")
+    end
+  end
+
+  context "using no input" do
+    before do
+      container.instance_exec do
+        register(:log, call: false) { "Persisted" }
+      end
+    end
+
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+        tee :process, with: :process
+        tee :persist, with: :persist
+        map :log, with: :log, input: []
+      end.new
+    }
+
+    it "can reference no input with the empty list" do
+      result = transaction.call(initial_input)
+
+      expect(result.value!).to eq('Persisted')
+    end
+  end
+
+  context "passing additional step arguments" do
+    before do
+      container.instance_exec do
+        register :log, -> process_output, persist_output, time { "Processed #{process_output} persisted as #{persist_output} on #{time}"  }
+      end
+    end
+
+    let(:transaction) {
+      Class.new do
+        include Dry::Transaction(container: Test::Container)
+        map :process, with: :process
+        map :persist, with: :persist
+        map :log, with: :log, input: [:process, :persist]
+      end.new
+    }
+
+    it "can combine previous outputs along with additional step arguments" do
+      result = transaction.with_step_args(log: "2019-01-01").call(initial_input)
+
+      expect(result.value!).to eq("Processed #{process_output} persisted as #{persist_output} on 2019-01-01")
+    end
+  end
+end

--- a/spec/unit/step_adapter_spec.rb
+++ b/spec/unit/step_adapter_spec.rb
@@ -1,0 +1,49 @@
+require "dry/monads/result"
+
+RSpec.describe Dry::Transaction::StepAdapter do
+  include Dry::Monads::Result::Mixin
+  
+  describe "#inputs" do
+    it "selects outputs for the steps listed in input option" do
+      adapter = described_class.new(Proc.new {}, Proc.new {}, { input: [:foo, :bar] })
+      outputs = [[:foo, Success("foo")], [:bar, Success("bar")], [:baz, Success("baz")]]
+
+      expect(adapter.inputs(outputs)).to eq([Success("foo"), Success("bar")])
+    end
+
+    it "keeps the order specified in input option" do
+      adapter = described_class.new(Proc.new {}, Proc.new {}, { input: [:bar, :foo] })
+      outputs = [[:foo, Success("foo")], [:bar, Success("bar")]]
+
+      expect(adapter.inputs(outputs)).to eq([Success("bar"), Success("foo")])
+    end
+
+    it "returns last output when input options is nil" do
+      adapter = described_class.new(Proc.new {}, Proc.new {}, { })
+      outputs = [[:foo, Success("foo")], [:bar, Success("bar")]]
+
+      expect(adapter.inputs(outputs)).to eq([Success("bar")])
+    end
+
+    it "returns the empty list when input options is the empty list" do
+      adapter = described_class.new(Proc.new {}, Proc.new {}, { input: [] })
+      outputs = [[:foo, Success("foo")]]
+
+      expect(adapter.inputs(outputs)).to eq([])
+    end
+  end
+
+  describe "#inputs_arity" do
+    it "returns length of input option" do
+      adapter = described_class.new(Proc.new {}, Proc.new {}, { input: [:foo, :bar] })
+
+      expect(adapter.inputs_arity).to eq(2)
+    end
+
+    it "returns 1 when no input option is given" do
+      adapter = described_class.new(Proc.new {}, Proc.new {}, { })
+
+      expect(adapter.inputs_arity).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This follows from [a conversation in the
forums](https://discourse.dry-rb.org/t/dry-transaction-operation-ignoring-input/670/4).

Basically, it transforms dry-transaction into a DSL for the result
monad, allowing any step to take as inputs the outputs from any other
previous step. It is controlled with the `input:` option in the step
adapter. For example:

```ruby
step :log, with: :log, input: [:process, :persist]
```

would make the `log` operation to take as positional arguments the
outputs of `:process` and `:persist` steps, along with any other
additional step argument.

Inputs order is not coupled to steps order, so you can do:

```ruby
step :log, with: :log, input: [:persist, :process]
```

You can always reference the initial transaction input with the
`:_initial` reserved word:

```ruby
step :log, with: :log, input: [:_initial]
```

An empty list corresponds to the "continue" or "then" (`>>`) monadic
operation.

If the `input:` option is not given, the behaviour defaults to be like
always: to take the last step output as input.

An alternative API could be more explicit about this being a DSL for
monads:

```ruby
step :log, with: :log, type: :bind, input: [:persist, :process]
step :log_two, with: :log_two, type: :then
```

In this case, `:type` would default to `:bind`, while `:then` would
ignore an `:input` option when it is given. This would be more explicit,
but it would add more complexity to the code and mainly to an end user
not familiar with monads.

**Important:** This commit breaks the `around:` step behaviour. If
dry-transaction becomes a DSL for monads, then there is no place for
`around:` as it is. I think we should redesign it making it something
between the transaction and the steps, but not a step adapter itself.
This way we can still have the steps being pure monadic code, while the
transaction's `around:` behaviour would deal with anything else.