### PR TITLE
Fix Ruby 2.6 warning

### DIFF
--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -23,7 +23,7 @@ module Dry
       attr_reader :call_args
 
       def initialize(adapter:, name:, operation_name:, operation: nil, options:, call_args: [])
-        @adapter = StepAdapter[adapter, operation, **options, step_name: name, operation_name: operation_name]
+        @adapter = StepAdapter[adapter, operation, { **options, step_name: name, operation_name: operation_name }]
         @name = name
         @operation_name = operation_name
         @call_args = call_args


### PR DESCRIPTION
Quick fix to address a syntax ambiguity for splatted hashes that now issues a warning on Ruby 2.6. The warning was: 

```
dry-transaction-0.13.0/lib/dry/transaction/step_adapter.rb:7: warning: in `[]': the last argument was passed as a single Hash
```