### PR TITLE
Resolve ruby 2.7 deprecation warnings

### DIFF
--- a/lib/dry/transaction/callable.rb
+++ b/lib/dry/transaction/callable.rb
@@ -31,6 +31,9 @@ module Dry
       def call(*args, &block)
         if arity.zero?
           operation.(&block)
+        elsif args.last.is_a?(Hash)
+          *prefix, last = args
+          operation.(*prefix, **last, &block)
         else
           operation.(*args, &block)
         end

--- a/lib/dry/transaction/callable.rb
+++ b/lib/dry/transaction/callable.rb
@@ -31,7 +31,7 @@ module Dry
       def call(*args, &block)
         if arity.zero?
           operation.(&block)
-        elsif args.last.is_a?(Hash)
+        elsif args.last.is_a?(Hash) && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
           *prefix, last = args
           operation.(*prefix, **last, &block)
         else

--- a/lib/dry/transaction/instance_methods.rb
+++ b/lib/dry/transaction/instance_methods.rb
@@ -16,7 +16,7 @@ module Dry
 
       def initialize(steps: (self.class.steps), listeners: nil, **operations)
         @steps = steps.map { |step|
-          operation = resolve_operation(step, operations)
+          operation = resolve_operation(step, **operations)
           step.with(operation: operation)
         }
         @operations = operations

--- a/spec/integration/passing_step_arguments_spec.rb
+++ b/spec/integration/passing_step_arguments_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Passing additional arguments to step operations' do
-  let(:call_transaction) { transaction.with_step_args(step_options).call(input) }
+  let(:call_transaction) { transaction.with_step_args(**step_options).call(input) }
 
   let(:transaction) {
     Class.new do


### PR DESCRIPTION
This PR resolves all deprecation warnings shown when running the specs with ruby 2.7.

* `dry-transaction/lib/dry/transaction/instance_methods.rb:19: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`
* `dry-transaction/lib/dry/transaction/callable.rb:35: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`
* `dry-transaction/spec/integration/passing_step_arguments_spec.rb:4`