### PR TITLE
Re-allow Hash-like parameters to be passed to steps

### DIFF
--- a/lib/dry/transaction/callable.rb
+++ b/lib/dry/transaction/callable.rb
@@ -41,6 +41,13 @@ module Dry
 
       private
 
+      # Ruby 2.7 gives a deprecation warning about passing a hash of parameters as the last argument
+      # to a method. Ruby 3.0 outright disallows it. This checks for that condition, but explicitly
+      # uses instance_of? rather than is_a? or kind_of?, because Hash like objects, specifically
+      # HashWithIndifferentAccess objects are provided by Rails as controller parameters, and often
+      # passed to dry-rb validators.
+      # In this case, it's better to leave the object as it's existing type, rather than implicitly
+      # convert it in to a hash with the double-splat (**) operator.
       def ruby_27_last_arg_hash?(args)
         args.last.instance_of?(Hash) && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
       end

--- a/lib/dry/transaction/callable.rb
+++ b/lib/dry/transaction/callable.rb
@@ -31,12 +31,18 @@ module Dry
       def call(*args, &block)
         if arity.zero?
           operation.(&block)
-        elsif args.last.instance_of?(Hash) && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+        elsif ruby_27_last_arg_hash?(args)
           *prefix, last = args
           operation.(*prefix, **last, &block)
         else
           operation.(*args, &block)
         end
+      end
+
+      private
+
+      def ruby_27_last_arg_hash?(args)
+        args.last.instance_of?(Hash) && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
       end
     end
   end

--- a/lib/dry/transaction/callable.rb
+++ b/lib/dry/transaction/callable.rb
@@ -31,7 +31,7 @@ module Dry
       def call(*args, &block)
         if arity.zero?
           operation.(&block)
-        elsif args.last.is_a?(Hash) && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+        elsif args.last.instance_of?(Hash) && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
           *prefix, last = args
           operation.(*prefix, **last, &block)
         else

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -499,7 +499,7 @@ RSpec.describe "Transactions" do
   context "hash-like arguments" do
     let(:sym_key_hash_class) {
       Class.new(Hash) {
-        def initialize hash
+        def initialize(hash)
           hash.keys.each do |key|
             hash[key.to_sym] = hash.delete(key)
           end
@@ -522,11 +522,11 @@ RSpec.describe "Transactions" do
 
     let(:dependencies) do
       {
-        validate: -> input { input[:email].nil? ? raise(Test::NotValidError, "email required") : input },
+        validate: -> input { input[:email].nil? ? raise(Test::NotValidError, "email required") : input }
       }
     end
 
-    let(:input) { sym_key_hash_class.new({ "name" => "Jane", "email" => "jane@doe.com" }) }
+    let(:input) { sym_key_hash_class.new({"name" => "Jane", "email" => "jane@doe.com"}) }
 
     it "returns a success" do
       expect(transaction.call(input)).to be_a Dry::Monads::Result::Success


### PR DESCRIPTION
Previous commit 49c8dc24cf8e826c5771ddce5ec631f7952354a1 fixed a ruby 2.7 (https://github.com/dry-rb/dry-transaction/issues/132) / ruby 3.0 issue (https://github.com/dry-rb/dry-transaction/issues/135) , where you are no longer allowed to pass hash structures as the last argument to a method.

However, this fix affected other types of objects, that may inherit from Hash, and behave in a very similar way to Hash, specifically HashWithIndifferentAccess.

HashWithIndifferentAccess is used as the default object type for Rails parameters, and as such, is often passed to validation steps, as a HashWithIndifferentAccess type. The underlying validation code is often written with that implicit expectation, and may use strings or symbols as keys. This breaks, when the parameter is transformed in to a simple Hash.

While, it would probably be ideal to be able to go back, and remove HashWithIndifferentAccess from validators, and tighten the expectations to explicitly use strings or symbols, this fix was a breaking change to validators build with Rails parameters in mind.

This commit adds a test with a simple HashWithIndifferentAccess like test class, and demonstrates typical validation code. Without the included fix, these tests fail on current master (49c8dc24cf8e826c5771ddce5ec631f7952354a1) but pass on the commit before the fixes (69e886005ceff48a8f917011ceaf1bf2b90d03e9). The included fix limits the scope of the previous fix to only apply explicitly to Hash instances, leaving "hash-like" objects untouched.