### PR TITLE
Remove notice about future of dry-transaction

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -15,10 +15,6 @@ sections:
   - custom-step-adapters
 ---
 
-^WARNING
-Please see [this discussion](https://github.com/dry-rb/dry-transaction/issues/127) about the future of dry-transaction
-^
-
 dry-transaction is a business transaction DSL. It provides a simple way to define a complex business transaction that includes processing over many steps and by many different objects. It makes error handling a primary concern by taking a “[Railway Oriented Programming](http://fsharpforfunandprofit.com/rop/)” approach to capturing and returning errors from any step in the transaction.
 
 `dry-transaction` is based on the following ideas:


### PR DESCRIPTION
Leaving this warning in is causing [some confusion](https://github.com/dry-rb/dry-transaction/issues/127#issuecomment-1076517763). The issue that is linked has been closed and @solnic said there will be a 1.0 release of `dry-transaction` (which I'm happy about).

Particularly, with `Hanami::Interactor` going away, I'd like to direct people to use `dry-transaction` instead, and the warning at the top makes that a little sketchy.
 
