### PR TITLE
Fix after zeitwerkify

### DIFF
--- a/dry-transaction.gemspec
+++ b/dry-transaction.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
 
   # to update dependencies edit project.yml
   spec.add_runtime_dependency "dry-container", ">= 0.2.8"
-  spec.add_runtime_dependency "dry-events", ">= 0.1.0"
+  spec.add_runtime_dependency "dry-events", ">= 0.4.0"
   spec.add_runtime_dependency "dry-matcher", ">= 0.7.0"
-  spec.add_runtime_dependency "dry-monads", ">= 0.4.0"
+  spec.add_runtime_dependency "dry-monads", ">= 0.5.0"
 
 end

--- a/lib/dry/transaction.rb
+++ b/lib/dry/transaction.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "dry/monads/result"
+require "dry/monads"
 require "dry/transaction/version"
 require "dry/transaction/step_adapters"
 require "dry/transaction/builder"

--- a/lib/dry/transaction/step.rb
+++ b/lib/dry/transaction/step.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'dry/monads/result'
-require 'dry/events/publisher'
+require 'dry/monads'
+require 'dry/events'
 require 'dry/transaction/step_failure'
 require 'dry/transaction/step_adapter'
 


### PR DESCRIPTION
Since dry-monads was switched to zeitwerk it seems brokes constant name resolving.

This minor patch fixes the initialization issue:

```
An error occurred while loading spec_helper.
Failure/Error: require "dry/monads/result"

NameError:
  uninitialized constant Dry::Monads::Result::Transformer
# ./lib/dry/transaction.rb:3:in `require'
# ./lib/dry/transaction.rb:3:in `<top (required)>'
# ./lib/dry-transaction.rb:3:in `require'
# ./lib/dry-transaction.rb:3:in `<top (required)>'
# ./spec/spec_helper.rb:11:in `require'
# ./spec/spec_helper.rb:11:in `<top (required)>'
No examples found.
```