### PR TITLE
Match multiple step names with `ResultMatcher` on failure

### DIFF
--- a/lib/dry/transaction/result_matcher.rb
+++ b/lib/dry/transaction/result_matcher.rb
@@ -10,9 +10,9 @@ module Dry
         resolve: -> result { result.value! }
       ),
       failure: Dry::Matcher::Case.new(
-        match: -> result, step_name = nil {
-          if step_name
-            result.failure? && result.failure.step.name == step_name
+        match: -> result, *step_names {
+          if step_names.any?
+            result.failure? && step_names.include?(result.failure.step.name)
           else
             result.failure?
           end

--- a/spec/unit/result_matcher_spec.rb
+++ b/spec/unit/result_matcher_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Transaction::ResultMatcher do
+  include Dry::Monads[:result]
+
+  describe "when failure" do
+    it "can match using multiple step names" do
+      expected = Object.new
+      actual = nil
+
+      failure = Failure(Dry::Transaction::StepFailure.new(Struct.new(:name).new(:step), expected))
+      Dry::Transaction::ResultMatcher.(failure) do |on|
+        on.success { raise }
+        on.failure(:step, :other_step) { |value| actual = value }
+      end
+
+      expect(actual).to be expected
+    end
+  end
+end


### PR DESCRIPTION
This makes it more convenient to handle failures from multiple steps in the same way.